### PR TITLE
PF algo refinements (better sync to what we do in CMSSW)

### DIFF
--- a/DiscretePFInputs.h
+++ b/DiscretePFInputs.h
@@ -13,6 +13,7 @@
 
 #include <cassert>
 #include <cstdlib>
+#include <cstdio>
 #include <cmath>
 #include <vector>
 

--- a/firmware/data.h
+++ b/firmware/data.h
@@ -70,9 +70,10 @@ struct TkObj {
 	pt_t hwPt, hwPtErr;
 	etaphi_t hwEta, hwPhi; // relative to the region center, at calo
 	z0_t hwZ0;
+	bool hwTightQuality;
 };
 inline void clear(TkObj & c) {
-    c.hwPt = 0; c.hwPtErr = 0; c.hwEta = 0; c.hwPhi = 0; c.hwZ0 = 0; 
+    c.hwPt = 0; c.hwPtErr = 0; c.hwEta = 0; c.hwPhi = 0; c.hwZ0 = 0; c.hwTightQuality = 0;
 }
 
 struct MuObj {

--- a/firmware/mp7pf_encoding.h
+++ b/firmware/mp7pf_encoding.h
@@ -23,6 +23,7 @@ inline void mp7_pack(TkObj track[N], MP7DataWord data[]) {
     for (unsigned int i = 0; i < N; ++i) {
         data[2*i+0+OFFS] = ( track[i].hwPtErr, track[i].hwPt );
         data[2*i+1+OFFS] = ( track[i].hwZ0, track[i].hwPhi, track[i].hwEta );
+        data[2*i+1+OFFS][30] = track[i].hwTightQuality;
     }
 }
 
@@ -68,6 +69,7 @@ inline void mp7_unpack(MP7DataWord data[], TkObj track[N]) {
         track[i].hwEta   = data[2*i+1+OFFS](9, 0);
         track[i].hwPhi   = data[2*i+1+OFFS](19,10);
         track[i].hwZ0    = data[2*i+1+OFFS](29,20);
+        track[i].hwTightQuality = data[2*i+1+OFFS][30];
     }
 }
 

--- a/firmware/simple_fullpfalgo.cpp
+++ b/firmware/simple_fullpfalgo.cpp
@@ -246,9 +246,11 @@ void em2calo_sumem(EmCaloObj emcalo[NEMCALO], bool isEM[NEMCALO], ap_uint<NCALO>
 }
 
 void tk2calo_tkalgo(TkObj track[NTRACK], bool isEle[NTRACK], bool isMu[NTRACK], ap_uint<NCALO> calo_track_link_bit[NTRACK], PFChargedObj pfout[NTRACK]) {
-    const pt_t TKPT_MAX = PFALGO3_TK_MAXINVPT; // 20 * PT_SCALE;
+    const pt_t TKPT_MAX_LOOSE = PFALGO3_TK_MAXINVPT_LOOSE; // 20 * PT_SCALE;
+    const pt_t TKPT_MAX_TIGHT = PFALGO3_TK_MAXINVPT_TIGHT; // 20 * PT_SCALE;
     for (int it = 0; it < NTRACK; ++it) {
-        bool good = isMu[it] || isEle[it] || (track[it].hwPt < TKPT_MAX) || calo_track_link_bit[it].or_reduce();
+        bool goodByPt = track[it].hwPt < (track[it].hwTightQuality ? TKPT_MAX_TIGHT : TKPT_MAX_LOOSE);
+        bool good = isMu[it] || isEle[it] || goodByPt || calo_track_link_bit[it].or_reduce();
         if (good) {
             pfout[it].hwPt  = track[it].hwPt;
             pfout[it].hwEta = track[it].hwEta;

--- a/firmware/simple_fullpfalgo.cpp
+++ b/firmware/simple_fullpfalgo.cpp
@@ -206,7 +206,7 @@ void em2calo_link(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], ap_uint<
 
 void tk2calo_tkerr2(TkObj track[NTRACK], int tkerr2[NTRACK]) {
     for (int it = 0; it < NTRACK; ++it) {
-        tkerr2[it] = (track[it].hwPtErr * track[it].hwPtErr) << 2; // we will want (2*error)^2
+        tkerr2[it] = (track[it].hwPtErr * track[it].hwPtErr);
     }
 }
 void tk2calo_sumtk(TkObj track[NTRACK], bool isEle[NTRACK], bool isMu[NTRACK], int tkerr2[NTRACK], ap_uint<NCALO> calo_track_link_bit[NTRACK], pt_t sumtk[NCALO], int sumtkerr2[NCALO]) {
@@ -270,7 +270,7 @@ void tk2calo_caloalgo(HadCaloObj calo[NCALO], pt_t sumtk[NCALO], int sumtkerr2[N
             calopt = calo[icalo].hwPt;
         } else {
             pt_t ptdiff = calo[icalo].hwPt - sumtk[icalo];
-            if (ptdiff > 0 && (ptdiff*ptdiff) > sumtkerr2[icalo]) {
+            if (ptdiff > 0 && (ptdiff*ptdiff) > (sumtkerr2[icalo] + (sumtkerr2[icalo] >> 1))) {
                 calopt = ptdiff;
             } else {
                 calopt = 0;

--- a/firmware/simple_fullpfalgo.cpp
+++ b/firmware/simple_fullpfalgo.cpp
@@ -294,7 +294,10 @@ void tk2em_emalgo(EmCaloObj calo[NEMCALO], pt_t sumtk[NEMCALO], bool isEM[NEMCAL
             photonPt[icalo] = calo[icalo].hwPt;
         } else {
             pt_t ptdiff = calo[icalo].hwPt - sumtk[icalo];
-            if (ptdiff*ptdiff <= ((calo[icalo].hwPtErr*calo[icalo].hwPtErr)<<2)) {
+            int ptdiff2 = ptdiff*ptdiff;
+            int sigma2 = (calo[icalo].hwPtErr*calo[icalo].hwPtErr);
+            int sigma2Lo = (sigma2 << 2), sigma2Hi = sigma2 + (sigma2 >> 1);
+            if ((ptdiff > 0 && ptdiff2 <= sigma2Hi) || (ptdiff < 0 && ptdiff2 < sigma2Lo)) {
                 photonPt[icalo] = 0;    
                 isEM[icalo] = true;
             } else if (ptdiff > 0) {
@@ -329,8 +332,8 @@ void em2calo_sub(HadCaloObj calo[NCALO], pt_t sumem[NCALO], bool keepcalo[NCALO]
     for (int icalo = 0; icalo < NCALO; ++icalo) {
         pt_t ptsub = calo[icalo].hwPt   - sumem[icalo];
         pt_t emsub = calo[icalo].hwEmPt - sumem[icalo];
-        if ((ptsub < (calo[icalo].hwPt >> 4)) || 
-                (calo[icalo].hwIsEM && (emsub < (calo[icalo].hwEmPt>>3)) && !keepcalo[icalo])) {
+        if ((ptsub <= (calo[icalo].hwPt >> 4)) || 
+                (calo[icalo].hwIsEM && (emsub <= (calo[icalo].hwEmPt>>3)) && !keepcalo[icalo])) {
             calo_out[icalo].hwPt   = 0;
             calo_out[icalo].hwEmPt = 0;
             calo_out[icalo].hwEta  = 0;

--- a/firmware/simple_fullpfalgo.h
+++ b/firmware/simple_fullpfalgo.h
@@ -20,6 +20,7 @@ void mp7wrapped_pfalgo3_full(MP7DataWord input[MP7_NCHANN], MP7DataWord output[M
 #define PFALGO3_DR2MAX_EM_CALO 525
 #define PFALGO3_DR2MAX_TK_MU   2101
 #define PFALGO3_DR2MAX_TK_EM   84
-#define PFALGO3_TK_MAXINVPT    80
+#define PFALGO3_TK_MAXINVPT_LOOSE    40
+#define PFALGO3_TK_MAXINVPT_TIGHT    80
 
 #endif

--- a/firmware/simple_fullpfalgo.h
+++ b/firmware/simple_fullpfalgo.h
@@ -9,6 +9,7 @@ int dr2_int(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2) ;
 template<int NB> ap_uint<NB>  dr2_int_cap(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2, ap_uint<NB> max) ;
 
 void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU], PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO], PFChargedObj outmu[NMU]) ;
+void pfalgo3_full_ref_set_debug(bool debug);
 void pfalgo3_full(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU], PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO], PFChargedObj outmu[NMU]) ;
 void mp7wrapped_pack_in(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU], MP7DataWord data[MP7_NCHANN]) ;
 void mp7wrapped_unpack_in(MP7DataWord data[MP7_NCHANN], EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU]) ;

--- a/run_hls_fullpfalgo.tcl
+++ b/run_hls_fullpfalgo.tcl
@@ -5,9 +5,9 @@
 ############################################################
 
 # open the project, don't forget to reset
-open_project -reset proj_fullpfalgo_15151504_240MHz_II6
+open_project -reset proj_fullpfalgo_15151504_240MHz_II2
 set_top pfalgo3_full
-add_files firmware/simple_fullpfalgo.cpp  -cflags "-DHLS_pipeline_II=6"
+add_files firmware/simple_fullpfalgo.cpp  -cflags "-DHLS_pipeline_II=2"
 add_files -tb simple_fullpfalgo_test.cpp
 add_files -tb simple_fullpfalgo_ref.cpp
 add_files -tb utils/pattern_serializer.cpp

--- a/run_hls_fullpfalgo.tcl
+++ b/run_hls_fullpfalgo.tcl
@@ -30,7 +30,7 @@ config_interface -trim_dangling_port
 # do stuff
 csim_design
 csynth_design
-#cosim_design -trace_level all
+cosim_design -trace_level all
 #export_design -format ip_catalog
 
 # exit Vivado HLS

--- a/simple_fullpfalgo_ref.cpp
+++ b/simple_fullpfalgo_ref.cpp
@@ -193,6 +193,7 @@ void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj 
 void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU], PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO], PFChargedObj outmu[NMU]) {
 
     if (g_debug_) {
+#ifdef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_MORE
         for (int i = 0; i < NTRACK; ++i) { if (track[i].hwPt == 0) continue;
             l1tpf_int::PropagatedTrack tk; fw2dpf::convert(track[i], tk); 
             printf("FW  \t track %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  calo ptErr %6d [ %7.2f ] \n", 
@@ -213,6 +214,7 @@ void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkOb
             printf("FW  \t muon  %3d: pt %8d [ %7.2f ]  muon eta %+7d [ %+5.2f ]  muon phi %+7d [ %+5.2f ]   \n", 
                                 i, muon.hwPt, muon.floatPt(), muon.hwEta, muon.floatEta(), muon.hwPhi, muon.floatPhi());
         } 
+#endif
     }
 
     // constants
@@ -305,10 +307,12 @@ void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkOb
             pt_t ptdiff = hadcalo_subem[ic].hwPt - calo_sumtk[ic];
             int sigmamult = (calo_sumtkErr2[ic] + (calo_sumtkErr2[ic] >> 1)); // this multiplies by 1.5 = sqrt(1.5)^2 ~ (1.2)^2
             if (g_debug_ && (hadcalo_subem[ic].hwPt > 0)) {
+#ifdef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_MORE
                 l1tpf_int::CaloCluster floatcalo; fw2dpf::convert(hadcalo_subem[ic], floatcalo); 
                 printf("FW  \t calo'  %3d pt %7d [ %7.2f ] eta %+7d [ %+5.2f ] has a sum track pt %7d, difference %7d +- %.2f \n",
                             ic, int(hadcalo_subem[ic].hwPt), floatcalo.floatPt(), int(hadcalo_subem[ic].hwEta), floatcalo.floatEta(), 
                                 int(calo_sumtk[ic]), int(ptdiff), std::sqrt(float(int(calo_sumtkErr2[ic]))));
+#endif
                         
             }
             if (ptdiff > 0 && ptdiff*ptdiff > sigmamult) {

--- a/simple_fullpfalgo_ref.cpp
+++ b/simple_fullpfalgo_ref.cpp
@@ -211,7 +211,8 @@ void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkOb
     }
 
     // constants
-    const pt_t     TKPT_MAX = PFALGO3_TK_MAXINVPT; // 20 * PT_SCALE;
+    const pt_t     TKPT_MAX_LOOSE = PFALGO3_TK_MAXINVPT_LOOSE; // 20 * PT_SCALE;
+    const pt_t     TKPT_MAX_TIGHT = PFALGO3_TK_MAXINVPT_TIGHT; // 20 * PT_SCALE;
     const int      DR2MAX   = PFALGO3_DR2MAX_TK_CALO;
     const int      DR2MAX_TM = PFALGO3_DR2MAX_TK_MU;
 
@@ -272,7 +273,9 @@ void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkOb
 
     // initialize good track bit
     bool track_good[NTRACK];
-    for (int it = 0; it < NTRACK; ++it) { track_good[it] = (track[it].hwPt < TKPT_MAX || isEle[it] || isMu[it]); }
+    for (int it = 0; it < NTRACK; ++it) { 
+        track_good[it] = (track[it].hwPt < (track[it].hwTightQuality ? TKPT_MAX_TIGHT : TKPT_MAX_LOOSE) || isEle[it] || isMu[it]); 
+    }
 
     // initialize output
     for (int ipf = 0; ipf < NTRACK; ++ipf) { outch[ipf].hwPt = 0; outch[ipf].hwEta = 0; outch[ipf].hwPhi = 0; outch[ipf].hwId = 0; outch[ipf].hwZ0 = 0; }

--- a/simple_fullpfalgo_ref.cpp
+++ b/simple_fullpfalgo_ref.cpp
@@ -112,21 +112,24 @@ void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj 
         pt_t photonPt;
         if (calo_sumtk[ic] > 0) {
             pt_t ptdiff = emcalo[ic].hwPt - calo_sumtk[ic];
-            if (ptdiff*ptdiff <= 4*sqr(emcalo[ic].hwPtErr)) {
+            int sigma2 = sqr(emcalo[ic].hwPtErr);
+            int sigma2Lo = 4*sigma2, sigma2Hi = sigma2 + (sigma2>>1);
+            int ptdiff2 = ptdiff*ptdiff;
+            if ((ptdiff > 0 && ptdiff2 <= sigma2Hi) || (ptdiff < 0 && ptdiff2 < sigma2Lo)) {
                 // electron
                 photonPt = 0; 
                 isEM[ic] = true;
-                if (g_debug_) printf("FW  \t emcalo %3d pt %7d flagged as electron\n", ic, int(emcalo[ic].hwPt));
+                if (g_debug_) printf("FW  \t emcalo %3d pt %7d ptdiff %7d [match window: -%.2f / +%.2f] flagged as electron\n", ic, int(emcalo[ic].hwPt), int(ptdiff), std::sqrt(float(sigma2Lo)), std::sqrt(float(sigma2Hi)));
             } else if (ptdiff > 0) {
                 // electron + photon
                 photonPt = ptdiff; 
                 isEM[ic] = true;
-                if (g_debug_) printf("FW  \t emcalo %3d pt %7d flagged as electron + photon of pt %7d\n", ic, int(emcalo[ic].hwPt), int(photonPt));
+                if (g_debug_) printf("FW  \t emcalo %3d pt %7d ptdiff %7d [match window: -%.2f / +%.2f] flagged as electron + photon of pt %7d\n", ic, int(emcalo[ic].hwPt), int(ptdiff), std::sqrt(float(sigma2Lo)), std::sqrt(float(sigma2Hi)), int(photonPt));
             } else {
                 // pion
                 photonPt = 0;
                 isEM[ic] = false;
-                if (g_debug_) printf("FW  \t emcalo %3d pt %7d flagged as pion\n", ic, int(emcalo[ic].hwPt));
+                if (g_debug_) printf("FW  \t emcalo %3d pt %7d ptdiff %7d [match window: -%.2f / +%.2f] flagged as pion\n", ic, int(emcalo[ic].hwPt), int(ptdiff), std::sqrt(float(sigma2Lo)), std::sqrt(float(sigma2Hi)));
             }
         } else {
             // photon
@@ -168,15 +171,15 @@ void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj 
         pt_t emdiff  = hadcalo[ih].hwEmPt - sub;
         pt_t alldiff = hadcalo[ih].hwPt - sub;
         if (g_debug_ && (hadcalo[ih].hwPt > 0)) {
-            printf("FW  \t calo   %3d pt %7d has a subtracted pt of %7d, empt %7d -> %7d\n",
-                        ih, int(hadcalo[ih].hwPt), int(alldiff), int(hadcalo[ih].hwEmPt), int(emdiff));
+            printf("FW  \t calo   %3d pt %7d has a subtracted pt of %7d, empt %7d -> %7d   isem %d keep %d \n",
+                        ih, int(hadcalo[ih].hwPt), int(alldiff), int(hadcalo[ih].hwEmPt), int(emdiff), int(hadcalo[ih].hwIsEM), keep);
                     
         }
-        if (alldiff < ( hadcalo[ih].hwPt >>  4 ) ) {
+        if (alldiff <= ( hadcalo[ih].hwPt >>  4 ) ) {
             hadcalo_out[ih].hwPt = 0;   // kill
             hadcalo_out[ih].hwEmPt = 0; // kill
             if (g_debug_ && (hadcalo[ih].hwPt > 0)) printf("FW  \t calo   %3d pt %7d --> discarded (zero pt)\n", ih, int(hadcalo[ih].hwPt));
-        } else if ((hadcalo[ih].hwIsEM && emdiff < ( hadcalo[ih].hwEmPt >> 3 )) && !keep) {
+        } else if ((hadcalo[ih].hwIsEM && emdiff <= ( hadcalo[ih].hwEmPt >> 3 )) && !keep) {
             hadcalo_out[ih].hwPt = 0;   // kill
             hadcalo_out[ih].hwEmPt = 0; // kill
             if (g_debug_ && (hadcalo[ih].hwPt > 0)) printf("FW  \t calo   %3d pt %7d --> discarded (zero em)\n", ih, int(hadcalo[ih].hwPt));

--- a/simple_fullpfalgo_ref.cpp
+++ b/simple_fullpfalgo_ref.cpp
@@ -1,7 +1,11 @@
 #include "firmware/data.h"
 #include "firmware/simple_fullpfalgo.h"
+#include "DiscretePFInputs.h"
+#include "utils/Firmware2DiscretePF.h"
 #include <cmath>
 #include <algorithm>
+
+bool g_debug_ = 0;
 
 template <typename T> int sqr(const T & t) { return t*t; }
 
@@ -75,76 +79,6 @@ void ptsort_ref(T in[NIn], T out[NOut]) {
 }
 
 
-void pfalgo3_calo_ref(HadCaloObj calo[NCALO], TkObj track[NTRACK], PFChargedObj outch[NTRACK], PFNeutralObj outne[NCALO]) {
-    // constants
-    const pt_t     TKPT_MAX = PFALGO3_TK_MAXINVPT; // 20 * PT_SCALE;
-    const int      DR2MAX   = PFALGO3_DR2MAX_TK_CALO;
-
-    // initialize sum track pt
-    pt_t calo_sumtk[NCALO], calo_subpt[NCALO];
-    int  calo_sumtkErr2[NCALO];
-    for (int ic = 0; ic < NCALO; ++ic) { calo_sumtk[ic] = 0;  calo_sumtkErr2[ic] = 0;}
-
-    // initialize good track bit
-    bool track_good[NTRACK];
-    for (int it = 0; it < NTRACK; ++it) { track_good[it] = (track[it].hwPt < TKPT_MAX); }
-
-    // initialize output
-    for (int ipf = 0; ipf < NTRACK; ++ipf) { outch[ipf].hwPt = 0; }
-    for (int ipf = 0; ipf < NSELCALO; ++ipf) { outne[ipf].hwPt = 0; }
-
-    // for each track, find the closest calo
-    for (int it = 0; it < NTRACK; ++it) {
-        if (track[it].hwPt > 0) {
-            //int  ibest = best_match_ref<NCALO,DR2MAX,true,HadCaloObj>(calo, track[it]);
-            int  ibest = best_match_with_pt_ref<NCALO,DR2MAX,HadCaloObj>(calo, track[it]);
-            if (ibest != -1) {
-                track_good[it] = 1;
-                calo_sumtk[ibest]    += track[it].hwPt;
-                calo_sumtkErr2[ibest] += sqr(track[it].hwPtErr);
-            }
-        }
-    }
-
-    for (int ic = 0; ic < NCALO; ++ic) {
-        if (calo_sumtk[ic] > 0) {
-            pt_t ptdiff = calo[ic].hwPt - calo_sumtk[ic];
-            if (ptdiff > 0 && ptdiff*ptdiff > 4*calo_sumtkErr2[ic]) {
-                calo_subpt[ic] = ptdiff;
-            } else {
-                calo_subpt[ic] = 0;
-            }
-        } else {
-            calo_subpt[ic] = calo[ic].hwPt;
-        }
-    }
-
-    // copy out charged hadrons
-    for (int it = 0; it < NTRACK; ++it) {
-        if (track_good[it]) {
-            outch[it].hwPt = track[it].hwPt;
-            outch[it].hwEta = track[it].hwEta;
-            outch[it].hwPhi = track[it].hwPhi;
-            outch[it].hwZ0 = track[it].hwZ0;
-            outch[it].hwId  = PID_Charged;
-        }
-    }
-
-    // copy out neutral hadrons
-    PFNeutralObj outne_all[NCALO];
-    for (int ipf = 0; ipf < NCALO; ++ipf) { outne_all[ipf].hwPt = 0; }
-    for (int ic = 0; ic < NCALO; ++ic) {
-        if (calo_subpt[ic] > 0) {
-            outne_all[ic].hwPt  = calo_subpt[ic];
-            outne_all[ic].hwEta = calo[ic].hwEta;
-            outne_all[ic].hwPhi = calo[ic].hwPhi;
-            outne_all[ic].hwId  = PID_Neutral;
-        }
-    }
-
-    ptsort_ref<PFNeutralObj,NCALO,NSELCALO>(outne_all, outne);
-}
-
 void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], bool isEle[NTRACK], bool isMu[NTRACK], PFNeutralObj outpho[NPHOTON], HadCaloObj hadcalo_out[NCALO]) {
     // constants
     const int DR2MAX_TE = PFALGO3_DR2MAX_TK_EM;
@@ -159,17 +93,18 @@ void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj 
     for (int it = 0; it < NTRACK; ++it) {
         if (track[it].hwPt > 0 && !isMu[it]) {
             tk2em[it] = best_match_ref<NEMCALO,DR2MAX_TE,false,EmCaloObj>(emcalo, track[it]);
-            // printf("C++: tk not 0 index = %i and matched calo index = %i \n", it, int(tk2em[it]) );
             if (tk2em[it] != -1) {
+                if (g_debug_) printf("FW  \t track  %3d pt %7d matched to em calo %3d pt %7d\n", it, int(track[it].hwPt), tk2em[it], int(emcalo[tk2em[it]].hwPt));
                 calo_sumtk[tk2em[it]] += track[it].hwPt;
             }
         } else {
         	tk2em[it] = -1;
         }
-        // printf("C++: tk index = %i and match = %i and sumtk = %i \n", it, int(tk2em[it]), int(calo_sumtk[tk2em[it]]));        
     }
 
-    // for (int ic = 0; ic < NEMCALO; ++ic) {  printf("C++: calo_sumtk[NEMCALO] = %i \n", int(calo_sumtk[ic])); }
+    if (g_debug_) {
+        for (int ic = 0; ic < NEMCALO; ++ic) {  if (emcalo[ic].hwPt > 0) printf("FW  \t emcalo %3d pt %7d has sumtk %7d\n", ic, int(emcalo[ic].hwPt), int(calo_sumtk[ic])); }
+    }
 
     for (int ic = 0; ic < NEMCALO; ++ic) {
         pt_t photonPt;
@@ -179,35 +114,44 @@ void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj 
                 // electron
                 photonPt = 0; 
                 isEM[ic] = true;
+                if (g_debug_) printf("FW  \t emcalo %3d pt %7d flagged as electron\n", ic, int(emcalo[ic].hwPt));
             } else if (ptdiff > 0) {
                 // electron + photon
                 photonPt = ptdiff; 
                 isEM[ic] = true;
+                if (g_debug_) printf("FW  \t emcalo %3d pt %7d flagged as electron + photon of pt %7d\n", ic, int(emcalo[ic].hwPt), int(photonPt));
             } else {
                 // pion
                 photonPt = 0;
                 isEM[ic] = false;
+                if (g_debug_) printf("FW  \t emcalo %3d pt %7d flagged as pion\n", ic, int(emcalo[ic].hwPt));
             }
         } else {
             // photon
             isEM[ic] = true;
             photonPt = emcalo[ic].hwPt;
+            if (g_debug_ && emcalo[ic].hwPt > 0) printf("FW  \t emcalo %3d pt %7d flagged as photon\n", ic, int(emcalo[ic].hwPt));
         }
         outpho[ic].hwPt  = photonPt;
         outpho[ic].hwEta = photonPt ? emcalo[ic].hwEta : etaphi_t(0);
         outpho[ic].hwPhi = photonPt ? emcalo[ic].hwPhi : etaphi_t(0);
         outpho[ic].hwId  = photonPt ? PID_Photon : particleid_t(0);
 
-        // printf("C++: emcalo index = %i and pt = %i and calo_sumtk = %i \n", ic, int(photonPt),int(calo_sumtk[ic]));
     }
 
     for (int it = 0; it < NTRACK; ++it) {
         isEle[it] = (tk2em[it] != -1) && isEM[tk2em[it]];
+        if (g_debug_ && isEle[it]) printf("FW  \t track  %3d pt %7d flagged as electron.\n", it, int(track[it].hwPt));
     }
 
     int em2calo[NEMCALO];
     for (int ic = 0; ic < NEMCALO; ++ic) {
         em2calo[ic] = best_match_ref<NCALO,DR2MAX_EH>(hadcalo, emcalo[ic]);
+        if (g_debug_ && (emcalo[ic].hwPt > 0)) {
+             printf("FW  \t emcalo %3d pt %7d isEM %d matched to hadcalo %7d pt %7d emPt %7d isEM %d\n", 
+                                ic, int(emcalo[ic].hwPt), isEM[ic], em2calo[ic], (em2calo[ic] >= 0 ? int(hadcalo[em2calo[ic]].hwPt) : -1), 
+                                (em2calo[ic] >= 0 ? int(hadcalo[em2calo[ic]].hwEmPt) : -1), (em2calo[ic] >= 0 ? int(hadcalo[em2calo[ic]].hwIsEM) : 0));
+        }
     }
     
     for (int ih = 0; ih < NCALO; ++ih) {
@@ -220,12 +164,19 @@ void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj 
         }
         pt_t emdiff  = hadcalo[ih].hwEmPt - sub;
         pt_t alldiff = hadcalo[ih].hwPt - sub;
+        if (g_debug_ && (hadcalo[ih].hwPt > 0)) {
+            printf("FW  \t calo   %3d pt %7d has a subtracted pt of %7d, empt %7d -> %7d\n",
+                        ih, int(hadcalo[ih].hwPt), int(alldiff), int(hadcalo[ih].hwEmPt), int(emdiff));
+                    
+        }
         if (alldiff < ( hadcalo[ih].hwPt >>  4 ) ) {
             hadcalo_out[ih].hwPt = 0;   // kill
             hadcalo_out[ih].hwEmPt = 0; // kill
-        } else if (hadcalo[ih].hwIsEM && emdiff < ( hadcalo[ih].hwEmPt >> 3 ) ) {
+            if (g_debug_ && (hadcalo[ih].hwPt > 0)) printf("FW  \t calo   %3d pt %7d --> discarded (zero pt)\n", ih, int(hadcalo[ih].hwPt));
+        } else if ((hadcalo[ih].hwIsEM && emdiff < ( hadcalo[ih].hwEmPt >> 3 ))) {
             hadcalo_out[ih].hwPt = 0;   // kill
             hadcalo_out[ih].hwEmPt = 0; // kill
+            if (g_debug_ && (hadcalo[ih].hwPt > 0)) printf("FW  \t calo   %3d pt %7d --> discarded (zero em)\n", ih, int(hadcalo[ih].hwPt));
         } else {
             hadcalo_out[ih].hwPt   = alldiff;   
             hadcalo_out[ih].hwEmPt = (emdiff > 0 ? emdiff : pt_t(0)); 
@@ -234,6 +185,29 @@ void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj 
 }
 
 void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU], PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO], PFChargedObj outmu[NMU]) {
+
+    if (g_debug_) {
+        for (int i = 0; i < NTRACK; ++i) { if (track[i].hwPt == 0) continue;
+            l1tpf_int::PropagatedTrack tk; fw2dpf::convert(track[i], tk); 
+            printf("FW  \t track %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  calo ptErr %6d [ %7.2f ] \n", 
+                                i, tk.hwPt, tk.floatPt(), tk.hwEta, tk.floatEta(), tk.hwPhi, tk.floatPhi(), tk.hwCaloPtErr, tk.floatCaloPtErr());
+        }
+        for (int i = 0; i < NEMCALO; ++i) { if (emcalo[i].hwPt == 0) continue;
+            l1tpf_int::CaloCluster em; fw2dpf::convert(emcalo[i], em); 
+            printf("FW  \t EM    %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  calo ptErr %6d [ %7.2f ] \n", 
+                                i, em.hwPt, em.floatPt(), em.hwEta, em.floatEta(), em.hwPhi, em.floatPhi(), em.hwPtErr, em.floatPtErr());
+        } 
+        for (int i = 0; i < NCALO; ++i) { if (hadcalo[i].hwPt == 0) continue;
+            l1tpf_int::CaloCluster calo; fw2dpf::convert(hadcalo[i], calo); 
+            printf("FW  \t calo  %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  calo emPt %7d [ %7.2f ]   isEM %d \n", 
+                                i, calo.hwPt, calo.floatPt(), calo.hwEta, calo.floatEta(), calo.hwPhi, calo.floatPhi(), calo.hwEmPt, calo.floatEmPt(), calo.isEM);
+        } 
+        for (int i = 0; i < NMU; ++i) { if (mu[i].hwPt == 0) continue;
+            l1tpf_int::Muon muon; fw2dpf::convert(mu[i], muon); 
+            printf("FW  \t muon  %3d: pt %8d [ %7.2f ]  muon eta %+7d [ %+5.2f ]  muon phi %+7d [ %+5.2f ]   \n", 
+                                i, muon.hwPt, muon.floatPt(), muon.hwEta, muon.floatEta(), muon.hwPhi, muon.floatPhi());
+        } 
+    }
 
     // constants
     const pt_t     TKPT_MAX = PFALGO3_TK_MAXINVPT; // 20 * PT_SCALE;
@@ -260,6 +234,7 @@ void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkOb
             for (int it = 0; it < NTRACK; ++it) {
                 if (track[it].hwPt <= tkPtMin) continue;
                 int dr = dr2_int(mu[im].hwEta, mu[im].hwPhi, track[it].hwEta, track[it].hwPhi);
+                //printf("deltaR2(mu %d float pt %5.1f, tk %2d float pt %5.1f) = int %d  (float deltaR = %.3f); int cut at %d\n", im, 0.25*int(mu[im].hwPt), it, 0.25*int(track[it].hwPt), dr, std::sqrt(float(dr))/229.2, PFALGO3_DR2MAX_TK_MU);
                 if (dr < drmin) { drmin = dr; ibest = it; }
             }
             if (ibest != -1) {
@@ -269,6 +244,9 @@ void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkOb
                 outmu[im].hwId  = PID_Muon;
                 outmu[im].hwZ0 = track[ibest].hwZ0;      
                 isMu[ibest] = 1;
+                if (g_debug_) printf("FW  \t muon %3d linked to track %3d \n", im, ibest);
+            } else {
+                if (g_debug_) printf("FW  \t muon %3d not linked to any track\n", im);
             }
         }
     }
@@ -301,6 +279,7 @@ void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkOb
             int  ibest = best_match_with_pt_ref<NCALO,DR2MAX,HadCaloObj>(hadcalo_subem, track[it]);
             //int  ibest = best_match_ref<NCALO,DR2MAX,true,HadCaloObj>(hadcalo_subem, track[it]);
             if (ibest != -1) {
+                if (g_debug_) printf("FW  \t track  %3d pt %7d matched to calo' %3d pt %7d\n", it, int(track[it].hwPt), ibest, int(hadcalo_subem[ibest].hwPt));
                 track_good[it] = 1;
                 calo_sumtk[ibest]    += track[it].hwPt;
                 calo_sumtkErr2[ibest] += sqr(track[it].hwPtErr);
@@ -311,7 +290,15 @@ void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkOb
     for (int ic = 0; ic < NCALO; ++ic) {
         if (calo_sumtk[ic] > 0) {
             pt_t ptdiff = hadcalo_subem[ic].hwPt - calo_sumtk[ic];
-            if (ptdiff > 0 && ptdiff*ptdiff > 4*calo_sumtkErr2[ic]) {
+            int sigmamult = 4*calo_sumtkErr2[ic]; 
+            if (g_debug_ && (hadcalo_subem[ic].hwPt > 0)) {
+                l1tpf_int::CaloCluster floatcalo; fw2dpf::convert(hadcalo_subem[ic], floatcalo); 
+                printf("FW  \t calo'  %3d pt %7d [ %7.2f ] eta %+7d [ %+5.2f ] has a sum track pt %7d, difference %7d +- %.2f \n",
+                            ic, int(hadcalo_subem[ic].hwPt), floatcalo.floatPt(), int(hadcalo_subem[ic].hwEta), floatcalo.floatEta(), 
+                                int(calo_sumtk[ic]), int(ptdiff), std::sqrt(float(int(calo_sumtkErr2[ic]))));
+                        
+            }
+            if (ptdiff > 0 && ptdiff*ptdiff > sigmamult) {
                 calo_subpt[ic] = ptdiff;
             } else {
                 calo_subpt[ic] = 0;
@@ -319,6 +306,7 @@ void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkOb
         } else {
             calo_subpt[ic] = hadcalo_subem[ic].hwPt;
         }
+        if (g_debug_ && (hadcalo_subem[ic].hwPt > 0)) printf("FW  \t calo'  %3d pt %7d ---> %7d \n", ic, int(hadcalo_subem[ic].hwPt), int(calo_subpt[ic]));
     }
 
     // copy out charged hadrons

--- a/simple_fullpfalgo_ref.cpp
+++ b/simple_fullpfalgo_ref.cpp
@@ -156,10 +156,11 @@ void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj 
     
     for (int ih = 0; ih < NCALO; ++ih) {
         hadcalo_out[ih] = hadcalo[ih];
-        pt_t sub = 0;
+        pt_t sub = 0; bool keep = false;
         for (int ic = 0; ic < NEMCALO; ++ic) {
-            if (isEM[ic] && (em2calo[ic] == ih)) {
-                sub += emcalo[ic].hwPt;
+            if (em2calo[ic] == ih) {
+                if (isEM[ic]) sub += emcalo[ic].hwPt;
+                else keep = true;
             }
         }
         pt_t emdiff  = hadcalo[ih].hwEmPt - sub;
@@ -173,7 +174,7 @@ void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj 
             hadcalo_out[ih].hwPt = 0;   // kill
             hadcalo_out[ih].hwEmPt = 0; // kill
             if (g_debug_ && (hadcalo[ih].hwPt > 0)) printf("FW  \t calo   %3d pt %7d --> discarded (zero pt)\n", ih, int(hadcalo[ih].hwPt));
-        } else if ((hadcalo[ih].hwIsEM && emdiff < ( hadcalo[ih].hwEmPt >> 3 ))) {
+        } else if ((hadcalo[ih].hwIsEM && emdiff < ( hadcalo[ih].hwEmPt >> 3 )) && !keep) {
             hadcalo_out[ih].hwPt = 0;   // kill
             hadcalo_out[ih].hwEmPt = 0; // kill
             if (g_debug_ && (hadcalo[ih].hwPt > 0)) printf("FW  \t calo   %3d pt %7d --> discarded (zero em)\n", ih, int(hadcalo[ih].hwPt));

--- a/simple_fullpfalgo_ref.cpp
+++ b/simple_fullpfalgo_ref.cpp
@@ -7,6 +7,8 @@
 
 bool g_debug_ = 0;
 
+void pfalgo3_full_ref_set_debug(bool debug) { g_debug_ = debug; }
+
 template <typename T> int sqr(const T & t) { return t*t; }
 
 template<int NCAL, int DR2MAX, bool doPtMin, typename CO_t>

--- a/simple_fullpfalgo_ref.cpp
+++ b/simple_fullpfalgo_ref.cpp
@@ -230,13 +230,17 @@ void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkOb
     // for each muon, find the closest track
     for (int im = 0; im < NMU; ++im) {
         if (mu[im].hwPt > 0) {
-            pt_t tkPtMin = mu[im].hwPt - 2*(mu[im].hwPtErr);
-            int  drmin = DR2MAX_TM, ibest = -1;
+            int ibest = -1;
+            int dptmin = mu[im].hwPt >> 1;
             for (int it = 0; it < NTRACK; ++it) {
-                if (track[it].hwPt <= tkPtMin) continue;
                 int dr = dr2_int(mu[im].hwEta, mu[im].hwPhi, track[it].hwEta, track[it].hwPhi);
                 //printf("deltaR2(mu %d float pt %5.1f, tk %2d float pt %5.1f) = int %d  (float deltaR = %.3f); int cut at %d\n", im, 0.25*int(mu[im].hwPt), it, 0.25*int(track[it].hwPt), dr, std::sqrt(float(dr))/229.2, PFALGO3_DR2MAX_TK_MU);
-                if (dr < drmin) { drmin = dr; ibest = it; }
+                if (dr < DR2MAX_TM) { 
+                    int dpt = std::abs(int(track[it].hwPt - mu[im].hwPt));
+                    if (dpt < dptmin) {
+                        dptmin = dpt; ibest = it; 
+                    }
+                }
             }
             if (ibest != -1) {
                 outmu[im].hwPt = track[ibest].hwPt;

--- a/simple_fullpfalgo_ref.cpp
+++ b/simple_fullpfalgo_ref.cpp
@@ -290,7 +290,7 @@ void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkOb
     for (int ic = 0; ic < NCALO; ++ic) {
         if (calo_sumtk[ic] > 0) {
             pt_t ptdiff = hadcalo_subem[ic].hwPt - calo_sumtk[ic];
-            int sigmamult = 4*calo_sumtkErr2[ic]; 
+            int sigmamult = (calo_sumtkErr2[ic] + (calo_sumtkErr2[ic] >> 1)); // this multiplies by 1.5 = sqrt(1.5)^2 ~ (1.2)^2
             if (g_debug_ && (hadcalo_subem[ic].hwPt > 0)) {
                 l1tpf_int::CaloCluster floatcalo; fw2dpf::convert(hadcalo_subem[ic], floatcalo); 
                 printf("FW  \t calo'  %3d pt %7d [ %7.2f ] eta %+7d [ %+5.2f ] has a sum track pt %7d, difference %7d +- %.2f \n",

--- a/utils/DiscretePF2Firmware.h
+++ b/utils/DiscretePF2Firmware.h
@@ -15,6 +15,7 @@ namespace dpf2fw {
         out.hwEta = in.hwEta; // @calo
         out.hwPhi = in.hwPhi; // @calo
         out.hwZ0 = in.hwZ0;
+        out.hwTightQuality = (in.hwStubs >= 6 && in.hwChi2 < 500);
     }
     void convert(const l1tpf_int::CaloCluster & in, HadCaloObj & out) {
         out.hwPt = in.hwPt;

--- a/utils/DiscretePF2Firmware.h
+++ b/utils/DiscretePF2Firmware.h
@@ -39,7 +39,6 @@ namespace dpf2fw {
     template<unsigned int NMAX, typename In, typename Out>
     void convert(const std::vector<In> & in, Out out[NMAX]) {
         for (unsigned int i = 0, n = std::min<unsigned int>(NMAX, in.size()); i < n; ++i) {
-            assert(in[i].hwPt >= 0);
             convert(in[i], out[i]);
         }
         for (unsigned int i = in.size(); i < NMAX; ++i) {

--- a/utils/Firmware2DiscretePF.h
+++ b/utils/Firmware2DiscretePF.h
@@ -1,0 +1,93 @@
+#ifndef FASTPUPPI_NTUPLERPRODUCER_FIRMWARE2DISCRETEPF_H
+#define FASTPUPPI_NTUPLERPRODUCER_FIRMWARE2DISCRETEPF_H
+
+/// NOTE: this include is not standalone, since the path to DiscretePFInputs is different in CMSSW & Vivado_HLS
+
+#include "../firmware/data.h"
+#include <vector>
+#include <cassert>
+
+namespace fw2dpf {
+
+    // convert inputs from discrete to firmware
+    inline void convert(const PFChargedObj & src, const l1tpf_int::PropagatedTrack & track, std::vector<l1tpf_int::PFParticle> &out) {
+        l1tpf_int::PFParticle pf;
+        pf.hwPt = src.hwPt;
+        pf.hwEta = src.hwEta;
+        pf.hwPhi = src.hwPhi;
+        pf.hwVtxEta = src.hwEta; // FIXME: get from the track
+        pf.hwVtxPhi = src.hwPhi; // before propagation
+        pf.track = track; // FIXME: ok only as long as there is a 1-1 mapping
+        pf.cluster.hwPt = 0;
+        switch(src.hwId) {
+            case PID_Electron: pf.hwId =  1; break;
+            case PID_Muon: pf.hwId =  4; break;
+            default: pf.hwId = 0; break;
+        };
+        pf.hwStatus = 0;
+        out.push_back(pf);
+    }
+    inline void convert(const PFNeutralObj & src, std::vector<l1tpf_int::PFParticle> &out) {
+        l1tpf_int::PFParticle pf;
+        pf.hwPt = src.hwPt;
+        pf.hwEta = src.hwEta;
+        pf.hwPhi = src.hwPhi;
+        pf.hwVtxEta = src.hwEta;
+        pf.hwVtxPhi = src.hwPhi;
+        pf.track.hwPt = 0;
+        pf.cluster.hwPt = src.hwPt;
+        switch(src.hwId) {
+            case PID_Photon: pf.hwId = 3; break;
+            default: pf.hwId = 2; break;
+        }
+        pf.hwStatus = 0;
+        out.push_back(pf);
+    }
+
+    // convert inputs from discrete to firmware
+    inline void convert(const TkObj & in, l1tpf_int::PropagatedTrack & out) {
+        out.hwPt = in.hwPt;
+        out.hwCaloPtErr = in.hwPtErr;
+        out.hwEta = in.hwEta; // @calo
+        out.hwPhi = in.hwPhi; // @calo
+        out.hwZ0 = in.hwZ0;
+    }
+    inline void convert(const HadCaloObj & in, l1tpf_int::CaloCluster & out) {
+        out.hwPt = in.hwPt;
+        out.hwEmPt = in.hwEmPt;
+        out.hwEta = in.hwEta;
+        out.hwPhi = in.hwPhi;
+        out.isEM = in.hwIsEM;
+    }
+    inline void convert(const EmCaloObj & in, l1tpf_int::CaloCluster & out) {
+        out.hwPt = in.hwPt;
+        out.hwPtErr = in.hwPtErr;
+        out.hwEta = in.hwEta;
+        out.hwPhi = in.hwPhi;
+    }
+    inline void convert(const MuObj & in, l1tpf_int::Muon & out) {
+        out.hwPt = in.hwPt;
+        out.hwEta = in.hwEta; // @calo
+        out.hwPhi = in.hwPhi; // @calo
+    }
+
+
+    template<unsigned int NMAX, typename In>
+    void convert(const In in[NMAX], std::vector<l1tpf_int::PFParticle> &out) {
+        for (unsigned int i = 0; i < NMAX; ++i) {
+            if (in[i].hwPt > 0) convert(in[i], out);
+        }
+    } 
+    template<unsigned int NMAX>
+    void convert(const PFChargedObj in[NMAX], std::vector<l1tpf_int::PropagatedTrack> srctracks, std::vector<l1tpf_int::PFParticle> &out) {
+        for (unsigned int i = 0; i < NMAX; ++i) {
+            if (in[i].hwPt > 0) {
+                assert(i < srctracks.size());
+                convert(in[i], srctracks[i], out);
+            }
+        }
+    }
+
+} // namespace
+
+#endif


### PR DESCRIPTION
On top of #17

Implement some refinements to the CMSSW PF algo that were in the missing in the firmware version. The impact in resource usage is negligible (few 1%).

* adjust sigma thresholds for track-calo and track-em linking
* in the em-subtraction step, preserve calo clusters linked to tracks that are not electrons
* in the em-subtraction step, use <= instead of < so that clusters with energy < 8 counts can also be discarded after subtraction.
* put a minimal fix to the current muon-track linking (while waiting for a reoptimized one)
* make track pt cuts dependent on track quality
* support verbose debug logging in the reference algo

A companion PR for FastPuppi containing some features to make the CMSSW more similar to the firmware will also be made.