### PR TITLE
Implement the seed finding as TreeReduce with Max operator

### DIFF
--- a/4.simple_jet/run_hls.tcl
+++ b/4.simple_jet/run_hls.tcl
@@ -1,7 +1,7 @@
 # open the project, don't forget to reset
 open_project -reset proj
 set_top algo_main
-add_files src/algo.cpp
+add_files src/algo.cpp -cflags -std=c++0x
 add_files -tb algo_test.cpp 
 add_files -tb algo_ref.cpp
 add_files -tb pfcands_ttbar.txt


### PR DESCRIPTION
Implement the seed finding as TreeReduce with Max operator.

- Gives identical results in CSIM. 
- LUTs decrease from 78065 to 67759
- DSPs increase from 489 to 507
- Same latency, II

The DSP increase is because the seed is now in an unknown location in the `work` array, so the DR must be computed for it.
Double counting of the seed pt is avoided by setting the seed pt to 0, and only using the seed eta, phi.

Introduce `-cflags -std=c++0x` for `constexpr` in algo.cpp