### PR TITLE
First implementation of endcap EG firmware

### DIFF
--- a/firmware/data.h
+++ b/firmware/data.h
@@ -264,13 +264,13 @@ inline void fill(PuppiObj &out, const HadCaloObj &src, pt_t puppiPt, puppiWgt_t 
 
 struct EGIsoEleParticle {
   pt_t hwPt;
-  etaphi_t hwEta;  // at calo face
-  etaphi_t hwPhi;
+  eta_t hwEta;  // at calo face
+  phi_t hwPhi;
   // uint16_t hwQual;
 
   // track parameters for electrons
-  etaphi_t hwVtxEta;
-  etaphi_t hwVtxPhi;
+  eta_t hwVtxEta;
+  phi_t hwVtxPhi;
   z0_t hwZ0;
   bool hwCharge;
   // uint16_t hwIso;
@@ -284,8 +284,8 @@ inline void clear(EGIsoEleParticle & c) {
 
 struct EGIsoParticle {
   pt_t hwPt;
-  etaphi_t hwEta;  // at calo face
-  etaphi_t hwPhi;
+  eta_t hwEta;  // at calo face
+  phi_t hwPhi;
   // uint16_t hwQual;
   // uint16_t hwIso;
 };

--- a/firmware/pftkegalgo.cpp
+++ b/firmware/pftkegalgo.cpp
@@ -1,0 +1,298 @@
+#include "pftkegalgo.h"
+#include <cassert>
+
+// #include "pfalgo_common.icc"
+
+
+
+
+//----- BEGIN ---------------
+// FIXME: get all these from common once merged
+
+template<int N> struct ct_log2_ceil { enum { value = ct_log2_ceil<(N/2)+(N%2)>::value + 1 }; };
+template<> struct ct_log2_ceil<2> { enum { value = 1 }; };
+template<> struct ct_log2_ceil<1> { enum { value = 0 }; };
+
+template<typename DR_T, typename INDEX_T> struct match {
+    DR_T val; INDEX_T idx;
+    match(DR_T dr, int i) : val(dr), idx(i) {}
+    match() {}
+
+    static match best(const match & m1, const match & m2) {
+        #pragma HLS inline
+        return (m1.val <= m2.val) ? m1 : m2;
+    }
+};
+
+template<typename MATCH_T, int N> struct picker_of_closest {
+    static MATCH_T pick(const MATCH_T in[N]) {
+        #pragma HLS inline
+        static constexpr int halfWidth = N / 2;
+        static constexpr int reducedSize = halfWidth + N % 2;
+        MATCH_T reduced[reducedSize];
+        #pragma HLS ARRAY_PARTITION variable=reduced complete
+        for (int i = 0; i < halfWidth; ++i) {
+            #pragma HLS unroll
+            reduced[i] = MATCH_T::best(in[2*i], in[2*i+1]);
+        }
+        if (halfWidth != reducedSize) {
+            reduced[reducedSize - 1] = in[N - 1];
+        }
+        return picker_of_closest<MATCH_T,reducedSize>::pick(reduced);
+    }
+};
+
+
+
+
+template<typename MATCH_T>
+struct picker_of_closest<MATCH_T,2> {
+    static MATCH_T pick(const MATCH_T vals[2]) {
+        #pragma HLS inline
+        return MATCH_T::best(vals[0],vals[1]);
+    }
+};
+
+template<typename MATCH_T>
+struct picker_of_closest<MATCH_T,1> {
+    static MATCH_T pick(const MATCH_T vals[1]) {
+        #pragma HLS inline
+        return vals[0];
+    }
+};
+
+
+template<int DR2MAX, int NCA, typename DR_T>
+ap_uint<NCA>  pick_closest(const DR_T calo_track_drval[NCA]) {
+    const DR_T eDR2MAX = DR2MAX;
+    typedef match<DR_T,ap_uint<ct_log2_ceil<NCA>::value>> match_t;
+    match_t candidates[NCA];
+    #pragma HLS ARRAY_PARTITION variable=candidates complete
+    for (int i = 0; i < NCA; ++i) {
+        candidates[i] = match_t(calo_track_drval[i], i);
+    }
+
+    match_t best = picker_of_closest<match_t, NCA>::pick(candidates);
+    ap_uint<NCA> calo_track_link_bit = 0;
+    calo_track_link_bit[best.idx] = (best.val >= eDR2MAX) ? 0 : 1;
+    return calo_track_link_bit;
+}
+
+
+template<typename T, int NIn, int NOut>
+void ptsort_hwopt(const T in[NIn], T out[NOut]) {
+    T tmp[NOut];
+    #pragma HLS ARRAY_PARTITION variable=tmp complete
+
+    for (int iout = 0; iout < NOut; ++iout) {
+        #pragma HLS unroll
+        tmp[iout].hwPt = 0;
+    }
+
+    for (int it = 0; it < NIn; ++it) {
+        for (int iout = NOut-1; iout >= 0; --iout) {
+            if (tmp[iout].hwPt <= in[it].hwPt) {
+                if (iout == 0 || tmp[iout-1].hwPt > in[it].hwPt) {
+                    tmp[iout] = in[it];
+                } else {
+                    tmp[iout] = tmp[iout-1];
+                }
+            }
+        }
+
+    }
+    for (int iout = 0; iout < NOut; ++iout) {
+        out[iout] = tmp[iout];
+    }
+
+}
+
+
+//-------- END
+
+
+ap_int<pt_t::width+1> ell_dpt_int_cap(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2, pt_t pt1, pt_t pt2, ap_int<pt_t::width+1> max) {
+#pragma HLS INLINE
+   // FIXME: this should be configurable
+    const ap_uint<10> cdeta = 16;
+    const ap_uint<10> cm = 256;
+
+    ap_int<etaphi_t::width+1> d_eta = (eta1-eta2);
+    ap_int<etaphi_t::width+1> d_phi = (phi1-phi2);
+
+    int ell = d_phi*d_phi + d_eta*d_eta*cdeta;
+    // FIXME: should be ap_uint<pt_t::width> ?
+    ap_int<pt_t::width+1> d_pt = abs(pt1 - pt2);
+    return (ell <= int(cm)) ? d_pt : max;
+}
+
+
+
+template<int DPTMAX>
+void calo2tk_ellipticdptvals(const EmCaloObj &em, const TkObj track[NTRACK], ap_int<pt_t::width+1> calo_track_dptval[NTRACK]) {
+#pragma HLS INLINE
+    // ap_int<pt_t::width+1>  ?
+    // FIXME: uint<pt_t::width>
+    // FIXME: some of this should be configurable
+    const ap_int<pt_t::width+1> eDPTMAX = DPTMAX;
+    const pt_t trkQualityPtMin_ = 40; // 10 GeV
+
+    track_loop: for (int itk = 0; itk < NTRACK; ++itk) {
+      if (track[itk].hwPt < trkQualityPtMin_ || em.hwPt == 0) {
+        calo_track_dptval[itk] = eDPTMAX;
+      } else {
+        calo_track_dptval[itk] = ell_dpt_int_cap(em.hwEta, em.hwPhi, track[itk].hwEta, track[itk].hwPhi, em.hwPt, track[itk].hwPt, eDPTMAX);
+        // std::cout << "[" << itk << "] dpt: " << calo_track_dptval[itk] << std::endl;
+      }
+    }
+
+}
+
+
+
+void link_emCalo2emCalo(const EmCaloObj emcalo[NEMCALOSEL_EGIN], ap_uint<NEMCALOSEL_EGIN> emCalo2emcalo_bit[NEMCALOSEL_EGIN]) {
+  #pragma HLS ARRAY_PARTITION variable=emcalo complete dim=1
+  #pragma HLS ARRAY_PARTITION variable=emCalo2emcalo_bit complete dim=1
+  #pragma HLS INLINE
+
+  // FIXME: configuration
+  const ap_int<etaphi_t::width+1>  dEtaMaxBrem_ = 5; // 0.02; -> round(0.02*4*180/3.14)
+  const ap_int<etaphi_t::width+1>  dPhiMaxBrem_ = 23; // 0.1; -> round(0.1*4*180/3.14)
+
+  // NOTE: we assume the input to be sorted!!!
+  brem_reco_outer_loop: for (int ic = 0; ic < NEMCALOSEL_EGIN; ++ic) {
+    auto &calo = emcalo[ic];
+    brem_reco_inner_loop: for (int jc = ic + 1; jc < NEMCALOSEL_EGIN; ++jc) {
+      auto &otherCalo = emcalo[jc];
+      if (calo.hwPt != 0 && otherCalo.hwPt != 0 &&
+        abs(otherCalo.hwEta - calo.hwEta) < dEtaMaxBrem_ &&
+          abs(otherCalo.hwPhi - calo.hwPhi) < dPhiMaxBrem_) {
+            emCalo2emcalo_bit[ic][jc] = 1;
+            emCalo2emcalo_bit[jc][jc] = 1; // use diagonal bit to mark the cluster as already used
+      }
+    }
+  }
+}
+
+
+
+
+
+void link_emCalo2tk(const EmCaloObj emcalo[NEMCALOSEL_EGIN],
+                    const TkObj track[NTRACK],
+                    ap_uint<NTRACK> emCalo2tk_bit[NEMCALOSEL_EGIN]) {
+  #pragma HLS INLINE
+
+  #pragma HLS ARRAY_PARTITION variable=emcalo complete dim=1
+  #pragma HLS ARRAY_PARTITION variable=track complete dim=1
+  #pragma HLS ARRAY_PARTITION variable=emCalo2tk_bit complete dim=1
+
+  // FIXME: parametrize
+  const int DPTMAX = 65535; // DPT = 16+1 bits -> max = 2^16-1 = ((1<<16)-1)
+  calo_loop: for (int ic = 0; ic < NEMCALOSEL_EGIN; ++ic) {
+    ap_int<pt_t::width+1> dptvals[NTRACK];
+    calo2tk_ellipticdptvals<DPTMAX>(emcalo[ic], track, dptvals);
+    emCalo2tk_bit[ic] = pick_closest<DPTMAX,NTRACK,ap_int<pt_t::width+1>>(dptvals);
+  }
+
+}
+
+
+void sel_emCalo(const EmCaloObj emcalo[NEMCALO], EmCaloObj emcalo_sel[NEMCALOSEL_EGIN]) {
+  #pragma HLS INLINE
+
+  EmCaloObj emcalo_selt[NEMCALO];
+  #pragma HLS ARRAY_PARTITION variable=emcalo_sel complete dim=1
+  #pragma HLS ARRAY_PARTITION variable=emcalo_selt complete dim=1
+  EmCaloObj emcalo_zero;
+  clear(emcalo_zero);
+  in_select_loop: for(int ic = 0; ic < NEMCALO; ++ic) {
+    emcalo_selt[ic] = (emcalo[ic].hwFlags == SELHWQUAL) ? emcalo[ic] : emcalo_zero;
+  }
+  ptsort_hwopt<EmCaloObj,NEMCALO,NEMCALOSEL_EGIN>(emcalo_selt, emcalo_sel);
+}
+
+
+void pftkegalgo(const EmCaloObj emcalo[NCALO], const TkObj track[NTRACK],
+  // ap_uint<NTRACK> emCalo2tk_bit[NEMCALOSEL_EGIN], ap_uint<NEMCALOSEL_EGIN> emCalo2emcalo_bit[NEMCALOSEL_EGIN],
+  EGIsoParticle photons[NEM_EGOUT], EGIsoEleParticle eles[NEM_EGOUT]) {
+  #pragma HLS PIPELINE II=1
+  #pragma HLS ARRAY_PARTITION variable=emcalo complete dim=1
+  #pragma HLS ARRAY_PARTITION variable=track complete dim=1
+
+  #pragma HLS ARRAY_PARTITION variable=photons complete dim=1
+  #pragma HLS ARRAY_PARTITION variable=eles complete dim=1
+
+  // FIXME: filter out qualities which are not useful for later processing (eg quality !=4 in HGC)
+  // EmCaloObj emcalo_sel[NEMCALOSEL_EGIN];
+  EmCaloObj emcalo_sel[NEMCALOSEL_EGIN];
+  EmCaloObj emcalo_selt[NEMCALO];
+  #pragma HLS ARRAY_PARTITION variable=emcalo_sel complete dim=1
+  #pragma HLS ARRAY_PARTITION variable=emcalo_selt complete dim=1
+  EmCaloObj emcalo_zero;
+  clear(emcalo_zero);
+  in_select_loop: for(int ic = 0; ic < NEMCALO; ++ic) {
+    emcalo_selt[ic] = (emcalo[ic].hwFlags == SELHWQUAL) ? emcalo[ic] : emcalo_zero;
+  }
+  ptsort_hwopt<EmCaloObj,NEMCALO,NEMCALOSEL_EGIN>(emcalo_selt, emcalo_sel);
+
+  // FIXME: shall we forseen the same selection step for tracks?
+  ap_uint<NTRACK> emCalo2tk_bit[NEMCALOSEL_EGIN];
+  ap_uint<NEMCALOSEL_EGIN> emCalo2emcalo_bit[NEMCALOSEL_EGIN];
+  #pragma HLS ARRAY_PARTITION variable=emCalo2tk_bit complete dim=1
+  #pragma HLS ARRAY_PARTITION variable=emCalo2emcalo_bit complete dim=1
+
+  // initialize
+  init_loop: for (int ic = 0; ic < NEMCALOSEL_EGIN; ++ic) {
+    emCalo2tk_bit[ic] = 0;
+    emCalo2emcalo_bit[ic] = 0;
+  }
+
+  #if defined(DOBREMRECOVERY)
+    link_emCalo2emCalo(emcalo_sel, emCalo2emcalo_bit);
+  #endif
+  //
+  link_emCalo2tk(emcalo_sel, track, emCalo2tk_bit);
+
+
+  EGIsoParticle photons_temp[NEMCALOSEL_EGIN];
+  EGIsoEleParticle eles_temp[NEMCALOSEL_EGIN];
+  #pragma HLS ARRAY_PARTITION variable=photons_temp complete dim=1
+  #pragma HLS ARRAY_PARTITION variable=eles_temp complete dim=1
+
+  loop_calo: for (int ic = 0; ic < NEMCALOSEL_EGIN; ++ic) {
+    loop_track_matched: for(int it = 0; it < NTRACK; ++it) {
+      if(emCalo2tk_bit[ic][it]) break;
+    }
+
+    pt_t ptcorr = emcalo_sel[ic].hwPt;
+    #if defined(DOBREMRECOVERY)
+      if(emCalo2emcalo_bit[ic][ic] != 1) { // FIXME: we still save the multiclusters used as brem???
+        // FIXME: we should set the quality bit as "brem-recovery performed"
+        loop_calo_brem_reco: for (int ioc = 0; ioc < NEMCALOSEL_EGIN; ++ioc) {
+          if(emCalo2emcalo_bit[ic][ioc]) {
+            ptcorr += emcalo_sel[ioc].hwPt;
+          }
+        }
+      }
+    #endif
+
+    photons_temp[ic].hwPt = ptcorr;
+    photons_temp[ic].hwEta = emcalo_sel[ic].hwEta;
+    photons_temp[ic].hwPhi = emcalo_sel[ic].hwPhi;
+
+    if(emCalo2tk_bit[ic]) {
+      eles_temp[ic].hwPt = ptcorr;
+      eles_temp[ic].hwEta = emcalo_sel[ic].hwEta;
+      eles_temp[ic].hwPhi = emcalo_sel[ic].hwPhi;
+      // FIXME: add track properties @ vertex using
+      //track[it]
+    } else {
+      clear(eles_temp[ic]);
+    }
+
+  }
+  ptsort_hwopt<EGIsoParticle,NEMCALOSEL_EGIN,NEM_EGOUT>(photons_temp, photons);
+  ptsort_hwopt<EGIsoEleParticle,NEMCALOSEL_EGIN,NEM_EGOUT>(eles_temp, eles);
+
+}

--- a/firmware/pftkegalgo.h
+++ b/firmware/pftkegalgo.h
@@ -1,0 +1,31 @@
+#ifndef FIRMWARE_PFTKEGALGO_H
+#define FIRMWARE_PFTKEGALGO_H
+
+// FIXME: move to data.h
+// FIXME: tune on the basis of the region occupancy
+// FIXME: this needs to go somewhere else
+#define SELHWQUAL 4
+
+#ifndef REG_HGCal
+
+  #ifndef CMSSW_GIT_HASH
+    #warning "REG_HGCal is not #defined, but this algorithm has only been tested there"
+  #endif
+#endif
+
+// #include "pfalgo_common.h"
+#include "data.h"
+
+void pftkegalgo(const EmCaloObj emcalo[NEMCALO], const TkObj track[NTRACK],
+  EGIsoParticle photons[NEM_EGOUT],
+  EGIsoEleParticle eles[NEM_EGOUT]
+) ;
+
+void link_emCalo2tk(const EmCaloObj emcalo[NEMCALOSEL_EGIN], const TkObj track[NTRACK], ap_uint<NTRACK> emCalo2tk_bit[NEMCALOSEL_EGIN]);
+
+void link_emCalo2emCalo(const EmCaloObj emcalo[NEMCALOSEL_EGIN], ap_uint<NEMCALOSEL_EGIN> emCalo2emcalo_bit[NEMCALOSEL_EGIN]);
+
+void sel_emCalo(const EmCaloObj emcalo[NEMCALO], EmCaloObj emcalo_sel[NEMCALOSEL_EGIN]);
+
+
+#endif

--- a/firmware/pftkegalgo.h
+++ b/firmware/pftkegalgo.h
@@ -13,7 +13,7 @@
   #endif
 #endif
 
-// #include "pfalgo_common.h"
+#include "pfalgo_common.h"
 #include "data.h"
 
 void pftkegalgo(const EmCaloObj emcalo[NEMCALO], const TkObj track[NTRACK],
@@ -26,6 +26,13 @@ void link_emCalo2tk(const EmCaloObj emcalo[NEMCALOSEL_EGIN], const TkObj track[N
 void link_emCalo2emCalo(const EmCaloObj emcalo[NEMCALOSEL_EGIN], ap_uint<NEMCALOSEL_EGIN> emCalo2emcalo_bit[NEMCALOSEL_EGIN]);
 
 void sel_emCalo(const EmCaloObj emcalo[NEMCALO], EmCaloObj emcalo_sel[NEMCALOSEL_EGIN]);
+
+// FIXME: I added this to have pfalgo_common.icc compile...
+#ifndef CMSSW_GIT_HASH
+#define PFALGO_DR2MAX_TK_CALO 525
+#define PFALGO_TK_MAXINVPT_LOOSE    40
+#define PFALGO_TK_MAXINVPT_TIGHT    80
+#endif
 
 
 #endif

--- a/pfalgo2hgc_test.cpp
+++ b/pfalgo2hgc_test.cpp
@@ -12,7 +12,7 @@ int main() {
     HumanReadablePatternSerializer debugHR("-", /*zerosuppress=*/true); // this will print on stdout, we'll use it for errors
 
     DiscretePFInputsReader inputs("TTbar_PU200_HGCal.dump");
-    
+
     // input TP objects
     HadCaloObj calo[NCALO]; EmCaloObj emcalo[NEMCALO]; TkObj track[NTRACK]; z0_t hwZPV;
     MuObj mu[NMU];
@@ -31,7 +31,7 @@ int main() {
     ap_uint<PACKING_DATA_SIZE> packed_input[PACKING_NCHANN], packed_output[PACKING_NCHANN];
     for (unsigned int i = 0; i < PACKING_NCHANN; ++i) { packed_input[i] = 0; packed_output[i] = 0; }
 #endif
-    
+
     // -----------------------------------------
     // run multiple tests
     for (int test = 1; test <= NTEST; ++test) {
@@ -39,7 +39,7 @@ int main() {
         if (!inputs.nextRegion(calo, emcalo, track, mu, hwZPV)) break;
 
 #if defined(PACKING_DATA_SIZE) && defined(PACKING_NCHANN)
-        pfalgo2hgc_pack_in(calo, track, mu, packed_input); 
+        pfalgo2hgc_pack_in(calo, track, mu, packed_input);
         serPatternsIn(packed_input);
         packed_pfalgo2hgc(packed_input, packed_output);
         serPatternsOut(packed_output);
@@ -66,7 +66,7 @@ int main() {
         for (int i = 0; i < NMU; ++i) {
             if (!pf_equals(outmupf_ref[i], outmupf[i], "PF Muon", i)) errors++;
             if (outmupf_ref[i].hwPt > 0) { ntot++; nmu++; }
-        }        
+        }
 
         if (errors != 0) {
             printf("Error in computing test %d (%d)\n", test, errors);

--- a/pftkegalgo_test.cpp
+++ b/pftkegalgo_test.cpp
@@ -1,0 +1,181 @@
+#include <cstdio>
+#include "firmware/pftkegalgo.h"
+
+#include "ref/pftkegalgo_ref.h"
+
+#include "utils/DiscretePFInputsReader.h"
+#include "utils/pattern_serializer.h"
+#include "utils/test_utils.h"
+
+#define NTEST 10000
+
+bool emcalo_equal(const EmCaloObj &emcalo1, const EmCaloObj &emcalo2) {
+  return emcalo1.hwPt == emcalo2.hwPt && emcalo1.hwEta == emcalo2.hwEta && emcalo1.hwPhi == emcalo2.hwPhi;
+}
+
+bool compare(const EGIsoEleParticle&ele1, const EGIsoEleParticle&ele2) {
+  // FIXME: add other parameters
+  return (ele1.hwPt == ele2.hwPt &&
+          ele1.hwEta == ele2.hwEta &&
+          ele1.hwPhi == ele2.hwPhi);
+}
+
+bool compare(const EGIsoParticle&ele1, const EGIsoParticle&ele2) {
+  // FIXME: add other parameters
+  return (ele1.hwPt == ele2.hwPt &&
+          ele1.hwEta == ele2.hwEta &&
+          ele1.hwPhi == ele2.hwPhi);
+}
+
+
+int main() {
+    HumanReadablePatternSerializer debugHR("-", /*zerosuppress=*/true); // this will print on stdout, we'll use it for errors
+
+    DiscretePFInputsReader inputs("DoubleElectron_PU200_HGCal.dump");
+
+    // input TP objects
+    HadCaloObj calo[NCALO]; EmCaloObj emcalo[NEMCALO]; TkObj track[NTRACK]; z0_t hwZPV;
+    MuObj mu[NMU];
+
+    // output PF objects
+    PFChargedObj outch[NTRACK], outch_ref[NTRACK];
+    PFNeutralObj outne[NSELCALO], outne_ref[NSELCALO];
+    PFChargedObj outmupf[NMU], outmupf_ref[NMU];
+
+    PFTkEGAlgo::pftkegalgo_config cfg(NTRACK, NEMCALO, NEMCALOSEL_EGIN, NEM_EGOUT);
+
+    // -----------------------------------------
+    // run multiple tests
+    int passed_tests = 0;
+    int nEles_tests = 0;
+    int nPhotons_tests = 0;
+
+    for (int test = 1; test <= NTEST; ++test) {
+      // std::cout << "------------ TEST: " << test << std::endl;
+        // get the inputs from the input object
+        if (!inputs.nextRegion(calo, emcalo, track, mu, hwZPV)) break;
+
+        // for(auto region: inputs.event().regions) {
+        //   printf("# of EM objects: %u\n", region.emcalo.size());
+        //   for(auto emc: region.emcalo) {
+        //     printf("   - hwFlags: %u\n", emc.hwFlags);
+        //   }
+        // }
+
+        // 0 - input cluster selection
+        EmCaloObj emcalo_sel[NEMCALOSEL_EGIN];
+        EmCaloObj emcalo_sel_ref[NEMCALOSEL_EGIN];
+        sel_emCalo(emcalo, emcalo_sel);
+        PFTkEGAlgo::sel_emCalo_ref(emcalo, emcalo_sel_ref);
+
+
+        // FIXME: determine output depth
+        int emCalo2tk_ref[NEMCALOSEL_EGIN], emCalo2tk[NEMCALOSEL_EGIN];
+        for(int id = 0; id < NEMCALOSEL_EGIN; id++) {
+          emCalo2tk_ref[id] = -1;
+          emCalo2tk[id] = -1;
+        }
+
+
+        int emCalo2emcalo_ref[NEMCALOSEL_EGIN], emCalo2emcalo[NEMCALOSEL_EGIN];
+        for(int id = 0; id < NEMCALOSEL_EGIN; id++) {
+          emCalo2emcalo_ref[id] = -1;
+          emCalo2emcalo[id] = -1;
+        }
+
+        // pftkegalgo(emcalo, track);
+        EGIsoParticle egphs_ref[NEM_EGOUT];
+        EGIsoEleParticle egele_ref[NEM_EGOUT];
+        PFTkEGAlgo::pftkegalgo_ref(cfg, emcalo_sel_ref, track, emCalo2tk_ref, emCalo2emcalo_ref, egphs_ref, egele_ref);
+
+        ap_uint<NTRACK> emCalo2tk_bit[NEMCALOSEL_EGIN];
+        ap_uint<NEMCALOSEL_EGIN> emCalo2emcalo_bit[NEMCALOSEL_EGIN];
+        EGIsoParticle egphs[NEM_EGOUT];
+        EGIsoEleParticle egele[NEM_EGOUT];
+
+        for(int i = 0; i < NEMCALOSEL_EGIN; i++) {
+          emCalo2tk_bit[i] = 0;
+          emCalo2emcalo_bit[i] = 0;
+        }
+
+        link_emCalo2emCalo(emcalo_sel, emCalo2emcalo_bit);
+        link_emCalo2tk(emcalo_sel, track, emCalo2tk_bit);
+
+        pftkegalgo(emcalo, track, egphs, egele) ;
+
+        for(int ic = 0; ic < NEMCALOSEL_EGIN; ic++) {
+          for(int it = 0; it < NTRACK; it++) {
+            if(emCalo2tk_bit[ic][it])
+              emCalo2tk[ic] = it;
+          }
+        }
+
+        for(int ic = 0; ic < NEMCALOSEL_EGIN; ic++) {
+          for(int it = 0; it < NEMCALOSEL_EGIN; it++) {
+            if(emCalo2emcalo_bit[ic][it])
+              emCalo2emcalo[ic] = it;
+          }
+        }
+
+        // -----------------------------------------
+        // validation against the reference algorithm
+        int errors = 0;
+        // int ntot = 0, nch = 0, nneu = 0, nmu = 0;
+        for(int i = 0; i < NEMCALOSEL_EGIN; i++) {
+          if (!emcalo_equal(emcalo_sel_ref[i], emcalo_sel[i])) {
+            std::cout << "emcalo_sel [" << i << "]" << " REF: " << emcalo_sel_ref[i].hwPt << " FW: " << emcalo_sel[i].hwPt << std::endl;
+          errors++;
+          }
+        }
+
+        for(int i = 0; i < NEMCALOSEL_EGIN; i++) {
+          if (emCalo2tk_ref[i] != emCalo2tk[i]) {
+            std::cout << "emCalo2tk [" << i << "]" << " REF: " << emCalo2tk_ref[i] << " FW: " << emCalo2tk[i] << std::endl;
+            errors++;
+          }
+        }
+
+        for(int i = 0; i < NEMCALOSEL_EGIN; i++) {
+          if (emCalo2emcalo_ref[i] != emCalo2emcalo[i]) {
+            std::cout << "emCalo2emcalo [" << i << "]" << " REF: " << emCalo2emcalo_ref[i] << " FW: " << emCalo2emcalo[i] << std::endl;
+            errors++;
+          }
+        }
+
+        for(int it = 0; it < NEM_EGOUT; it++) {
+          if(egele_ref[it].hwPt > 0) {
+            nEles_tests++;
+            if(!compare(egele_ref[it], egele[it])) {
+              errors++;
+              std::cout << "[" << it << "] REF ele pt: " << egele_ref[it].hwPt << " FW ele pt: " << egele[it].hwPt << std::endl;
+            }
+          }
+        }
+
+        for(int it = 0; it < NEM_EGOUT; it++) {
+          if(egphs_ref[it].hwPt > 0) {
+            nPhotons_tests++;
+            if(!compare(egphs_ref[it], egphs[it])) {
+              errors++;
+              std::cout << "[" << it << "] REF photon pt: " << egphs_ref[it].hwPt << " FW photon pt: " << egphs[it].hwPt << std::endl;
+            }
+
+          }
+        }
+
+
+        if (errors != 0) {
+            printf("Error in computing test %d (%d)\n", test, errors);
+        //     printf("Inputs: \n"); debugHR.dump_inputs(calo, track, mu);
+        //     printf("Reference output: \n"); debugHR.dump_outputs(outch_ref, outne_ref, outmupf_ref);
+        //     printf("Current output: \n"); debugHR.dump_outputs(outch, outne, outmupf);
+            return 1;
+        } else {
+          passed_tests++;
+            // printf("Passed test %d\n", test);
+        }
+    }
+    printf("Passed %d tests (%d electrons, %d photons)\n", passed_tests, nEles_tests, nPhotons_tests);
+
+    return 0;
+}

--- a/pftkegalgo_test.cpp
+++ b/pftkegalgo_test.cpp
@@ -17,7 +17,8 @@ bool compare(const EGIsoEleParticle&ele1, const EGIsoEleParticle&ele2) {
   // FIXME: add other parameters
   return (ele1.hwPt == ele2.hwPt &&
           ele1.hwEta == ele2.hwEta &&
-          ele1.hwPhi == ele2.hwPhi);
+          ele1.hwPhi == ele2.hwPhi &&
+          ele1.hwZ0 == ele2.hwZ0);
 }
 
 bool compare(const EGIsoParticle&ele1, const EGIsoParticle&ele2) {
@@ -111,9 +112,10 @@ int main() {
         }
 
         for(int ic = 0; ic < NEMCALOSEL_EGIN; ic++) {
+          if(emCalo2emcalo_bit[ic][ic]) continue;
           for(int it = 0; it < NEMCALOSEL_EGIN; it++) {
             if(emCalo2emcalo_bit[ic][it])
-              emCalo2emcalo[ic] = it;
+              emCalo2emcalo[it] = ic;
           }
         }
 
@@ -148,6 +150,9 @@ int main() {
             if(!compare(egele_ref[it], egele[it])) {
               errors++;
               std::cout << "[" << it << "] REF ele pt: " << egele_ref[it].hwPt << " FW ele pt: " << egele[it].hwPt << std::endl;
+              std::cout << "    REF ele Z0: " << egele_ref[it].hwZ0 << " FW ele z0: " << egele[it].hwZ0 << std::endl;
+
+
             }
           }
         }

--- a/ref/pftkegalgo_ref.cpp
+++ b/ref/pftkegalgo_ref.cpp
@@ -1,0 +1,338 @@
+#include "pftkegalgo_ref.h"
+
+
+#include "../utils/Firmware2DiscretePF.h"
+#include "../utils/DiscretePF2Firmware.h"
+
+#include <cmath>
+#include <cstdio>
+#include <algorithm>
+#include <memory>
+#include <iostream>
+
+
+
+int g_pftkegalgo_debug_ref_ = 0;
+
+using namespace PFTkEGAlgo;
+// void PFTkEGAlgo::initRegion(Region &r) const {
+//   // FIXME: assume imput is sorted already
+//   r.egobjs.clear();
+// }
+float PFTkEGAlgo::deltaPhi(float phi1, float phi2) {
+  // reduce to [-pi,pi]
+  float x = phi1 - phi2;
+  float o2pi = 1. / (2. * M_PI);
+  if (std::abs(x) <= float(M_PI))
+      return x;
+  float n = std::round(x * o2pi);
+  return x - n * float(2. * M_PI);
+}
+
+void PFTkEGAlgo::link_emCalo2emCalo(const std::vector<l1tpf_impl::CaloCluster>& emcalo,
+                        std::vector<int> &emCalo2emCalo) {
+  // FIXME: needs configuration
+  bool filterHwQuality_ = true;
+  int caloHwQual_ = 4;
+  float dEtaMaxBrem_ = 0.02;
+  float dPhiMaxBrem_ = 0.1;
+  // NOTE: we assume the input to be sorted!!!
+  for (int ic = 0, nc = emcalo.size(); ic < nc; ++ic) {
+    auto &calo = emcalo[ic];
+    if (filterHwQuality_ && calo.hwFlags != caloHwQual_)
+      continue;
+
+    if (emCalo2emCalo[ic] != -1)
+      continue;
+
+    for (int jc = ic + 1; jc < nc; ++jc) {
+      if (emCalo2emCalo[jc] != -1)
+        continue;
+
+      auto &otherCalo = emcalo[jc];
+      if (filterHwQuality_ && otherCalo.hwFlags != caloHwQual_)
+        continue;
+
+      if (fabs(otherCalo.floatEta() - calo.floatEta()) < dEtaMaxBrem_ &&
+          fabs(deltaPhi(otherCalo.floatPhi(), calo.floatPhi())) < dPhiMaxBrem_) {
+        emCalo2emCalo[jc] = ic;
+      }
+    }
+  }
+}
+
+
+
+void PFTkEGAlgo::link_emCalo2tk(const std::vector<l1tpf_impl::CaloCluster> &emcalo,
+                                const std::vector<l1tpf_impl::PropagatedTrack> &track,
+                                std::vector<int> &emCalo2tk) {
+
+
+
+
+  // FIXME: configuration
+  int caloHwQual_ = 4;
+  float dEtaMax = 0.0174533; // FIXME: should be 0.01 but it is too small give eta precision. We use  0.0174533 hwEta: 4
+  float dPhiMax = 0.07;
+  bool filterHwQuality_ = true;
+  int debug_ = 1;
+  float trkQualityPtMin_ = 10.;
+  if (debug_ > 10)
+    std::cout << "[link_emCalo2tk]" << std::endl;
+
+  for (int ic = 0, nc = emcalo.size(); ic < nc; ++ic) {
+    auto &calo = emcalo[ic];
+
+    if (filterHwQuality_ && calo.hwFlags != caloHwQual_)
+      continue;
+
+    if (debug_ > 10) {
+      std::cout << "[REF] EM calo [" << ic << "] hwFlags: " << calo.hwFlags << std::endl;
+      std::cout << "--- calo: pt: " << calo.floatPt() << " eta: " << calo.floatEta() << " phi: " << calo.floatPhi()
+                << std::endl;
+    }
+
+    float dPtMin = 999;
+    for (int itk = 0, ntk = track.size(); itk < ntk; ++itk) {
+      const auto &tk = track[itk];
+      if (tk.floatPt() < trkQualityPtMin_)
+        continue;
+
+      if (debug_ > 10) {
+        std::cout << "[REF] tk [" << itk << " tk: pt: " << tk.floatPt() << " eta: " << tk.floatEta() << " phi: " << tk.floatPhi()
+        << std::endl;
+      }
+
+      float d_phi = deltaPhi(tk.floatPhi(), calo.floatPhi());
+      float d_eta = tk.floatEta() - calo.floatEta();  // We only use it squared
+
+      // if (debug_ > 0)
+      //   std::cout << " deta: " << fabs(d_eta) << " dphi: " << d_phi
+      //             << " ell: " << ((d_phi / dPhiMax) * (d_phi / dPhiMax)) + ((d_eta / dEtaMax) * (d_eta / dEtaMax))
+      //             << std::endl;
+      // std::cout << "Global abs eta: " << r.globalAbsEta(calo.floatEta())
+      //           << " abs eta: " << fabs(calo.floatEta()) << std::endl;
+
+      if ((((d_phi / dPhiMax) * (d_phi / dPhiMax)) + ((d_eta / dEtaMax) * (d_eta / dEtaMax))) < 1.) {
+        if (debug_ > 0) {
+              if (debug_ <= 10){
+          std::cout << "[REF] EM calo [" << ic << "] hwFlags: " << calo.hwFlags << std::endl;
+          std::cout << "--- calo: pt: " << calo.floatPt() << " eta: " << calo.floatEta() << " phi: " << calo.floatPhi()
+                    << std::endl;
+          std::cout << "[REF] tk [" << itk << " tk: pt: " << tk.floatPt() << " eta: " << tk.floatEta() << " phi: " << tk.floatPhi()
+                    << std::endl;
+                  }
+          std::cout << "    pass elliptic " << std::endl;
+        }
+        // NOTE: for now we implement only best pt match. This is NOT what is done in the L1TkElectronTrackProducer
+        if (fabs(tk.floatPt() - calo.floatPt()) < dPtMin) {
+          if (debug_ > 0)
+            std::cout << "     best pt match: " << fabs(tk.floatPt() - calo.floatPt()) << std::endl;
+          emCalo2tk[ic] = itk;
+          dPtMin = fabs(tk.floatPt() - calo.floatPt());
+        }
+      }
+    }
+  }
+}
+
+
+
+
+
+void PFTkEGAlgo::pftkegalgo_ref_set_debug(int debug) { g_pftkegalgo_debug_ref_ = debug; }
+
+bool PFTkEGAlgo::hwpt_sort(const l1tpf_impl::CaloCluster &i, const l1tpf_impl::CaloCluster &j) {
+  return (i.hwPt > j.hwPt);
+}
+
+
+void PFTkEGAlgo::sel_emCalo_ref(const EmCaloObj emcalo[/*cfg.nCALO*/],
+  EmCaloObj emcalo_sel_ref[/*cfg.nCALO*/]) {
+
+
+  std::vector<l1tpf_impl::CaloCluster> emcalos(NEMCALO);
+  for(int ic = 0; ic < NEMCALO; ic++) {
+    // if (emcalo[i].hwPt == 0) continue;
+    l1tpf_impl::CaloCluster c;
+    fw2dpf::convert(emcalo[ic], c);
+    // if(emcalo[ic].hwPt != 0)
+    // std::cout << "[" << ic << "] EmCaloObj pt: " << emcalo[ic].hwPt << " CaloCluster pt: " << c.hwPt << std::endl;
+    emcalos.push_back(c);
+  }
+  std::sort(emcalos.begin(), emcalos.end(), hwpt_sort);
+
+  for(int ic = 0; ic < NEMCALOSEL_EGIN; ic++) {
+    clear(emcalo_sel_ref[ic]);
+  }
+
+  int jc = 0;
+  for(int ic = 0; ic < NEMCALO; ic++) {
+    if(emcalos[ic].hwFlags == 4) {
+      // std::cout << "[" << ic << "] EmCaloObj pt: " << emcalos[ic].hwPt << " hwflags: " << emcalos[ic].hwFlags << std::endl;
+      dpf2fw::convert(emcalos[ic], emcalo_sel_ref[jc++]);
+      if(jc == NEMCALOSEL_EGIN) break;
+    }
+  }
+}
+
+
+
+void PFTkEGAlgo::pftkegalgo_ref(const pftkegalgo_config &cfg,
+                    const EmCaloObj emcalo[/*cfg.nCALO*/],
+                    const TkObj track[/*cfg.nTRACK*/],
+                    int emCalo2tk_ref[],
+                    int emCalo2emcalo_ref[],
+                    EGIsoParticle egphs_ref[],
+                    EGIsoEleParticle egele_ref[]) {
+
+  // printf("[pftkegalgo_ref]\n");
+
+  bool doBremRecovery_ = true;
+  //     if (g_pftkegalgo_debug_ref_) {
+  // #ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
+  PFTkEGAlgo::Region reg;
+
+  // std::vector<l1tpf_impl::PropagatedTrack> tracks;
+  // std::vector<l1tpf_impl::CaloCluster> emcalos;
+
+
+  for (unsigned int i = 0; i < cfg.nTRACK; ++i) { if (track[i].hwPt == 0) continue;
+      l1tpf_impl::PropagatedTrack tk; fw2dpf::convert(track[i], tk);
+      // printf("FW  \t track %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  calo ptErr %6d [ %7.2f ]   tight %d\n",
+      //                     i, tk.hwPt, tk.floatPt(), tk.hwEta, tk.floatEta(), tk.hwPhi, tk.floatPhi(), tk.hwCaloPtErr, tk.floatCaloPtErr(), int(track[i].hwTightQuality));
+      reg.track.push_back(tk);
+  }
+  for (unsigned int i = 0; i < cfg.nEMCALO; ++i) { if (emcalo[i].hwPt == 0) continue;
+      l1tpf_impl::CaloCluster c; fw2dpf::convert(emcalo[i], c);
+      // printf("FW  \t EM calo  %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  calo emPt %7d [ %7.2f ]   isEM %d \n",
+      //                     i, c.hwPt, c.floatPt(), c.hwEta, c.floatEta(), c.hwPhi, c.floatPhi(), c.hwEmPt, c.floatEmPt(), c.isEM);
+      reg.emcalo.push_back(c);
+  }
+
+  // printf("# tracks: %3d # emcalos: %3d\n", tracks.size(), emcalos.size());
+
+
+  std::vector<int> emCalo2emCalo(reg.emcalo.size(), -1);
+  if (doBremRecovery_)
+    link_emCalo2emCalo(reg.emcalo, emCalo2emCalo);
+  // convert to array
+  for(int id = 0; id < cfg.nEMCALO && id < emCalo2emCalo.size(); id++) {
+      emCalo2emcalo_ref[id] = emCalo2emCalo[id];
+    }
+
+
+  std::vector<int> emCalo2tk(reg.emcalo.size(), -1);
+  link_emCalo2tk(reg.emcalo, reg.track, emCalo2tk);
+
+  // convert to array
+  for(int id = 0; id < cfg.nEMCALO && id < emCalo2tk.size(); id++) {
+    emCalo2tk_ref[id] = emCalo2tk[id];
+  }
+
+
+  eg_algo(reg, emCalo2emCalo, emCalo2tk);
+
+  // std::cout << "# EG photons: " << reg.egphotons.size() << " # eles: " << reg.egeles.size() << std::endl;
+
+  // initialize and fill the output arrays
+  for(int ic = 0; ic != cfg.nEM_EGOUT; ++ic) {
+    clear(egphs_ref[ic]);
+    clear(egele_ref[ic]);
+  }
+
+  for(int ic = 0; ic != reg.egphotons.size(); ++ic) {
+    egphs_ref[ic] = reg.egphotons[ic];
+  }
+  for(int ic = 0; ic != reg.egeles.size(); ++ic) {
+    egele_ref[ic] = reg.egeles[ic];
+  }
+
+}
+
+
+void PFTkEGAlgo::eg_algo(Region &r,
+                         const std::vector<int> &emCalo2emCalo,
+                         const std::vector<int> &emCalo2tk) {
+
+  bool filterHwQuality_ = true;
+  int caloHwQual_ = 4;
+  bool doBremRecovery_ = true;
+
+  for (int ic = 0, nc = r.emcalo.size(); ic < nc; ++ic) {
+    auto &calo = r.emcalo[ic];
+    if (filterHwQuality_ && calo.hwFlags != caloHwQual_)
+      continue;
+
+    int itk = emCalo2tk[ic];
+
+
+    // check if brem recovery is on
+    if (!doBremRecovery_) {
+      // 1. create EG objects before brem recovery
+      addEgObjsToPF(r, ic, calo.hwFlags, calo.hwPt, itk);
+      continue;
+    }
+    
+    // check if the cluster has already been used in a brem reclustering
+    if (emCalo2emCalo[ic] != -1)
+      continue;
+
+    int ptBremReco = calo.hwPt;
+
+    for (int jc = ic; jc < nc; ++jc) {
+      if (emCalo2emCalo[jc] == ic) {
+        auto &otherCalo = r.emcalo[jc];
+        ptBremReco += otherCalo.hwPt;
+      }
+    }
+
+    // 2. create EG objects with brem recovery
+    // FIXME: duplicating the object is suboptimal but this is done for keeping things as in TDR code...
+    addEgObjsToPF(r, ic, calo.hwFlags + 1, ptBremReco, itk);
+  }
+}
+
+EGIsoParticle &PFTkEGAlgo::addEGIsoToPF(std::vector<EGIsoParticle> &egobjs,
+                                        const l1tpf_impl::CaloCluster &calo,
+                                        const int hwQual,
+                                        const int ptCorr) {
+  EGIsoParticle egiso;
+  egiso.hwPt = ptCorr;
+  egiso.hwEta = calo.hwEta;
+  egiso.hwPhi = calo.hwPhi;
+  // egiso.hwQual = hwQual;
+  // egiso.hwIso = 0;
+  egobjs.push_back(egiso);
+  return egobjs.back();
+}
+
+EGIsoEleParticle &PFTkEGAlgo::addEGIsoEleToPF(std::vector<EGIsoEleParticle> &egobjs,
+                                              const l1tpf_impl::CaloCluster &calo,
+                                              const l1tpf_impl::PropagatedTrack &track,
+                                              const int hwQual,
+                                              const int ptCorr) {
+  EGIsoEleParticle egiso;
+  egiso.hwPt = ptCorr;
+  egiso.hwEta = calo.hwEta;
+  egiso.hwPhi = calo.hwPhi;
+
+  // egiso.hwVtxEta = track.hwVtxEta;
+  // egiso.hwVtxPhi = track.hwVtxPhi;
+  // egiso.hwZ0 = track.hwZ0;
+  // egiso.hwCharge = track.hwCharge;
+
+  // egiso.hwQual = hwQual;
+  // egiso.hwIso = 0;
+  egobjs.push_back(egiso);
+  return egobjs.back();
+}
+
+void PFTkEGAlgo::addEgObjsToPF(
+    Region &r, const int calo_idx, const int hwQual, const int ptCorr, const int tk_idx) {
+  EGIsoParticle &egobj = addEGIsoToPF(r.egphotons, r.emcalo[calo_idx], r.emcalo[calo_idx].hwFlags + 1, ptCorr);
+  if (tk_idx != -1) {
+    // egobj.ele_idx = r.egeles.size();
+    addEGIsoEleToPF(r.egeles, r.emcalo[calo_idx], r.track[tk_idx], r.emcalo[calo_idx].hwFlags + 1, ptCorr);
+  }
+}

--- a/ref/pftkegalgo_ref.cpp
+++ b/ref/pftkegalgo_ref.cpp
@@ -99,7 +99,7 @@ void PFTkEGAlgo::link_emCalo2tk(const std::vector<l1tpf_impl::CaloCluster> &emca
         continue;
 
       if (debug_ > 10) {
-        std::cout << "[REF] tk [" << itk << " tk: pt: " << tk.floatPt() << " eta: " << tk.floatEta() << " phi: " << tk.floatPhi()
+        std::cout << "[REF] tk [" << itk << "] tk: pt: " << tk.floatPt() << " eta: " << tk.floatEta() << " phi: " << tk.floatPhi() << " z0: " << tk.hwZ0
         << std::endl;
       }
 
@@ -119,7 +119,7 @@ void PFTkEGAlgo::link_emCalo2tk(const std::vector<l1tpf_impl::CaloCluster> &emca
           std::cout << "[REF] EM calo [" << ic << "] hwFlags: " << calo.hwFlags << std::endl;
           std::cout << "--- calo: pt: " << calo.floatPt() << " eta: " << calo.floatEta() << " phi: " << calo.floatPhi()
                     << std::endl;
-          std::cout << "[REF] tk [" << itk << " tk: pt: " << tk.floatPt() << " eta: " << tk.floatEta() << " phi: " << tk.floatPhi()
+          std::cout << "[REF] tk [" << itk << " tk: pt: " << tk.floatPt() << " eta: " << tk.floatEta() << " phi: " << tk.floatPhi() << " z0: " << tk.hwZ0
                     << std::endl;
                   }
           std::cout << "    pass elliptic " << std::endl;
@@ -273,7 +273,7 @@ void PFTkEGAlgo::eg_algo(Region &r,
       addEgObjsToPF(r, ic, calo.hwFlags, calo.hwPt, itk);
       continue;
     }
-    
+
     // check if the cluster has already been used in a brem reclustering
     if (emCalo2emCalo[ic] != -1)
       continue;
@@ -319,7 +319,7 @@ EGIsoEleParticle &PFTkEGAlgo::addEGIsoEleToPF(std::vector<EGIsoEleParticle> &ego
 
   // egiso.hwVtxEta = track.hwVtxEta;
   // egiso.hwVtxPhi = track.hwVtxPhi;
-  // egiso.hwZ0 = track.hwZ0;
+  egiso.hwZ0 = track.hwZ0;
   // egiso.hwCharge = track.hwCharge;
 
   // egiso.hwQual = hwQual;

--- a/ref/pftkegalgo_ref.h
+++ b/ref/pftkegalgo_ref.h
@@ -1,0 +1,75 @@
+#ifndef PFTKEGALGO_REF_H
+#define PFTKEGALGO_REF_H
+#ifndef CMSSW_GIT_HASH
+  #include "../DiscretePFInputs.h"
+#else
+  #include "../../interface/DiscretePFInputs.h"
+#endif
+
+#include "../firmware/pfalgo2hgc.h"
+#include "pfalgo_common_ref.h"
+
+
+
+namespace PFTkEGAlgo {
+
+  struct pftkegalgo_config {
+      unsigned int nTRACK;
+      unsigned int nEMCALO;
+      unsigned int nEMCALOSEL_EGIN;
+      unsigned int nEM_EGOUT;
+
+      pftkegalgo_config(unsigned int nTrack, unsigned int nEmCalo, unsigned int nEmCaloSel_in, unsigned int nEmOut) :
+          nTRACK(nTrack), nEMCALO(nEmCalo), nEMCALOSEL_EGIN(nEmCaloSel_in), nEM_EGOUT(nEmOut) {}
+  };
+
+  struct Region {
+    std::vector<l1tpf_impl::CaloCluster> emcalo;
+    std::vector<l1tpf_impl::PropagatedTrack> track;
+    std::vector<EGIsoParticle> egphotons;
+    std::vector<EGIsoEleParticle> egeles;
+  };
+
+  void pftkegalgo_ref_set_debug(int debug) ;
+
+  void pftkegalgo_ref(const pftkegalgo_config &cfg,
+                      const EmCaloObj emcalo[/*cfg.nCALO*/],
+                      const TkObj track[/*cfg.nTRACK*/],
+                      int emCalo2tk_ref[],
+                      int emCalo2emcalo_ref[],
+                      EGIsoParticle egphs_ref[],
+                      EGIsoEleParticle egele_ref[]) ;
+
+  void link_emCalo2emCalo(const std::vector<l1tpf_impl::CaloCluster>& emcalo,
+                          std::vector<int> &emCalo2emCalo);
+
+  void link_emCalo2tk(const std::vector<l1tpf_impl::CaloCluster> &emcalo,
+                      const std::vector<l1tpf_impl::PropagatedTrack> &track,
+                      std::vector<int> &emCalo2tk);
+
+  float deltaPhi(float phi1, float phi2);
+
+  bool hwpt_sort(const l1tpf_impl::CaloCluster &i, const l1tpf_impl::CaloCluster &j);
+
+  void sel_emCalo_ref(const EmCaloObj emcalo[/*cfg.nCALO*/],
+                      EmCaloObj emcalo_sel_ref[/*cfg.nCALO*/]);
+
+  void eg_algo(Region &r,
+               const std::vector<int> &emCalo2emCalo,
+               const std::vector<int> &emCalo2tk);
+
+   EGIsoParticle &addEGIsoToPF(std::vector<EGIsoParticle> &egobjs,
+                               const l1tpf_impl::CaloCluster &calo,
+                               const int hwQual,
+                               const int ptCorr);
+
+   EGIsoEleParticle &addEGIsoEleToPF(std::vector<EGIsoEleParticle> &egobjs,
+                                     const l1tpf_impl::CaloCluster &calo,
+                                     const l1tpf_impl::PropagatedTrack &track,
+                                     const int hwQual,
+                                     const int ptCorr);
+
+   void addEgObjsToPF(Region &r, const int calo_idx, const int hwQual, const int ptCorr, const int tk_idx);
+}
+
+#endif

--- a/run_hls_ptkegalgo.tcl
+++ b/run_hls_ptkegalgo.tcl
@@ -1,0 +1,38 @@
+# get the configuration
+#source config_hls_fullpfalgo_mp7.tcl
+set pfBoard "none"
+#set pfBoard "VCU118"
+set pfReg "HGCal"
+set cflags "-std=c++0x -DREG_${pfReg} -DBOARD_${pfBoard}"
+
+# open the project, don't forget to reset
+open_project -reset "proj_tkeg${pfReg}_${pfBoard}"
+
+
+if { $pfBoard == "none" } {
+    set_top pftkegalgo
+} else {
+    set_top packed_pftkegalgo
+}
+add_files firmware/pftkegalgo.cpp -cflags "${cflags}"
+add_files -tb pftkegalgo_test.cpp  -cflags "${cflags}"
+add_files -tb ref/pftkegalgo_ref.cpp  -cflags "${cflags}"
+add_files -tb ref/pfalgo_common_ref.cpp  -cflags "${cflags}"
+add_files -tb utils/pattern_serializer.cpp -cflags "${cflags}"
+add_files -tb utils/test_utils.cpp -cflags "${cflags}"
+add_files -tb data/TTbar_PU200_HGCal.dump
+
+# reset the solution
+open_solution -reset "solution"
+set_part {xcvu9p-flga2104-2L-e}
+create_clock -period 3.0 -name default
+
+config_interface -trim_dangling_port
+# do stuff
+csim_design
+csynth_design
+cosim_design -trace_level all
+#export_design -format ip_catalog -vendor "cern-cms" -version ${l1pfIPVersion} -description "${l1pfTopFunc}"
+
+# exit Vivado HLS
+exit

--- a/utils/DiscretePF2Firmware.h
+++ b/utils/DiscretePF2Firmware.h
@@ -36,6 +36,7 @@ namespace dpf2fw {
         out.hwPtErr = in.hwPtErr;
         out.hwEta = in.hwEta;
         out.hwPhi = in.hwPhi;
+        out.hwFlags = in.hwFlags;
     }
     inline void convert(const l1tpf_impl::Muon & in, MuObj & out) {
         out.hwPt = in.hwPt;

--- a/utils/Firmware2DiscretePF.h
+++ b/utils/Firmware2DiscretePF.h
@@ -128,6 +128,7 @@ namespace fw2dpf {
         out.hwPtErr = in.hwPtErr;
         out.hwEta = in.hwEta;
         out.hwPhi = in.hwPhi;
+        out.hwFlags = in.hwFlags;
         out.src = nullptr;
     }
     inline void convert(const MuObj & in, l1tpf_impl::Muon & out) {
@@ -143,7 +144,7 @@ namespace fw2dpf {
         for (unsigned int i = 0; i < NMAX; ++i) {
             if (in[i].hwPt > 0) convert(in[i], out);
         }
-    } 
+    }
     template<typename In>
     void convert(unsigned int NMAX, const In in[], std::vector<l1tpf_impl::PFParticle> &out) {
         for (unsigned int i = 0; i < NMAX; ++i) {
@@ -154,12 +155,12 @@ namespace fw2dpf {
         for (unsigned int i = 0; i < NMAX; ++i) {
             if (in[i].hwPt > 0) convert_puppi(in[i], nullptr, out);
         }
-    } 
+    }
     inline void convert_puppi(unsigned int NMAX, const PuppiObj in[], const std::vector<l1tpf_impl::PropagatedTrack> & srctracks, std::vector<l1tpf_impl::PFParticle> &out) {
         for (unsigned int i = 0; i < NMAX; ++i) {
             if (in[i].hwPt > 0) convert_puppi(in[i], &srctracks[i], out);
         }
-    } 
+    }
 
 
 
@@ -180,7 +181,7 @@ namespace fw2dpf {
             }
         }
     }
- 
+
 } // namespace
 
 #endif


### PR DESCRIPTION


First implementation of EG photon and electron objects.

Implements:

- filtering of input EM clusters based on quality flag
- bremsstrahlung recovery cluster matching
- calo-track matching using elliptic criteria
- reference implementation  "CMSSW-like"


NOTE: Several things are still pretty unrefined and needs further work, among which the input and out multiplicities and the data formats (huge number of FIXME to be addressed)

![Screenshot 2021-01-11 at 15 02 50_newBranch](https://user-images.githubusercontent.com/4802196/104195088-75635f00-5422-11eb-8053-021cf41b30a9.png)

