### PR TITLE
Bitonic sort for Puppi candidates from @amarini

### DIFF
--- a/firmware/data.h
+++ b/firmware/data.h
@@ -223,6 +223,9 @@ struct PuppiObj {
             #endif
             hwData(8,0) = w(8,0); 
         }
+
+        inline bool operator<(const PuppiObj&b) const { return hwPt < b.hwPt; }
+        inline bool operator>(const PuppiObj&b) const { return hwPt > b.hwPt; }
 };
 inline void clear(PuppiObj & c) {
     c.hwPt = 0; c.hwEta = 0; c.hwPhi = 0; c.hwId = 0; c.hwData = 0;

--- a/multififo_regionizer/regionizer_pf_puppi_test_tm18.cpp
+++ b/multififo_regionizer/regionizer_pf_puppi_test_tm18.cpp
@@ -18,11 +18,9 @@
 #include <vector>
 #include <string>
 
-#include "sort/bitonic_sort_new.h"
+#include "../sort/bitonic_sort_new.h"
 #define TLEN REGIONIZERNCLOCKS 
 
-inline const bool operator<(const PuppiObj&a , const PuppiObj&b){ return a.hwPt<b.hwPt;}
-inline const bool operator>(const PuppiObj&a , const PuppiObj&b){ return a.hwPt>b.hwPt;}
 
 int main(int argc, char **argv) {
     pfalgo_config pfcfg(NTRACK,NCALO,NMU, NSELCALO,
@@ -266,7 +264,7 @@ int main(int argc, char **argv) {
                 std::copy(outallne, outallne+NALLNEUTRALS, outpresort+NTRACK);
                 PuppiObj outsorted[NPUPPIFINALSORTED];
                 //puppisort_and_crop_ref(NTRACK+NALLNEUTRALS, NPUPPIFINALSORTED, outpresort, outsorted);
-                sort_and_crop_ref(NTRACK+NALLNEUTRALS, NPUPPIFINALSORTED, outpresort, outsorted) ;
+                bitonic_sort_and_crop_ref(NTRACK+NALLNEUTRALS, NPUPPIFINALSORTED, outpresort, outsorted) ;
                 l1pf_pattern_pack<NTRACK+NALLNEUTRALS,0>(outpresort, all_channels_puppi);
                 l1pf_pattern_pack<NPUPPIFINALSORTED,0>(outsorted, all_channels_puppisort);
             }

--- a/multififo_regionizer/regionizer_pf_puppi_test_tm18.cpp
+++ b/multififo_regionizer/regionizer_pf_puppi_test_tm18.cpp
@@ -18,8 +18,11 @@
 #include <vector>
 #include <string>
 
+#include "sort/bitonic_sort_new.h"
 #define TLEN REGIONIZERNCLOCKS 
 
+inline const bool operator<(const PuppiObj&a , const PuppiObj&b){ return a.hwPt<b.hwPt;}
+inline const bool operator>(const PuppiObj&a , const PuppiObj&b){ return a.hwPt>b.hwPt;}
 
 int main(int argc, char **argv) {
     pfalgo_config pfcfg(NTRACK,NCALO,NMU, NSELCALO,
@@ -262,7 +265,8 @@ int main(int argc, char **argv) {
                 std::copy(outallch, outallch+NTRACK, outpresort);
                 std::copy(outallne, outallne+NALLNEUTRALS, outpresort+NTRACK);
                 PuppiObj outsorted[NPUPPIFINALSORTED];
-                puppisort_and_crop_ref(NTRACK+NALLNEUTRALS, NPUPPIFINALSORTED, outpresort, outsorted);
+                //puppisort_and_crop_ref(NTRACK+NALLNEUTRALS, NPUPPIFINALSORTED, outpresort, outsorted);
+                sort_and_crop_ref(NTRACK+NALLNEUTRALS, NPUPPIFINALSORTED, outpresort, outsorted) ;
                 l1pf_pattern_pack<NTRACK+NALLNEUTRALS,0>(outpresort, all_channels_puppi);
                 l1pf_pattern_pack<NPUPPIFINALSORTED,0>(outsorted, all_channels_puppisort);
             }

--- a/sort/bitonic_sort_new.h
+++ b/sort/bitonic_sort_new.h
@@ -2,24 +2,7 @@
 #ifndef BITONIC_NEW_H
 #define BITONIC_NEW_H
 
-    template <typename T>
-inline T max(T a, T b)  
-{  
-    return (a < b)? b : a;  
-}  
-
-    template <typename T>
-inline T min(T a, T b)  
-{  
-    return (a < b)? a : b;  
-}  
-
-int get_pow2_size(unsigned int n){
-    if (n && !(n&(n-1)))return n;
-    int count=0;
-    while(n) {n>>=1;++count;}
-    return 1<<count;
-}
+#include<algorithm>
 
 unsigned int PowerOf2LessThan(unsigned int n){
     unsigned int i=1;
@@ -41,7 +24,7 @@ void bitonicMerge(T in[], int InSize,T out[],int OutSize, bool dir)
 
     // size == 1 -> pass through
     if (InSize<=1) { 
-        for(int i=0;i<min(InSize,OutSize);++i) out[i]=in[i]; 
+        for(int i=0;i<std::min(InSize,OutSize);++i) out[i]=in[i]; 
         return;
     }
 
@@ -102,15 +85,15 @@ void bitonicSort(T in[],int Start, int InSize,T out[], int OutSize, bool dir )
 {
     if (InSize <= 1) // copy in-> out and exit
     {
-        for(int i=0;i<min(InSize,OutSize);++i) out[i] = in[i+Start]; 
+        for(int i=0;i<std::min(InSize,OutSize);++i) out[i] = in[i+Start]; 
         return ;
     }
 
     int  LowerInSize = InSize / 2;
     int  UpperInSize = InSize - LowerInSize; //-- UpperSize >= LowerSize
 
-    int  LowerOutSize = min( OutSize , LowerInSize );
-    int  UpperOutSize = min( OutSize , UpperInSize );
+    int  LowerOutSize = std::min( OutSize , LowerInSize );
+    int  UpperOutSize = std::min( OutSize , UpperInSize );
 
     // sorted output
     T OutTmp[LowerOutSize+UpperOutSize];
@@ -135,8 +118,8 @@ void bitonicSort(T in[],int Start, int InSize,T out[], int OutSize, bool dir )
     }
 }
 
-    template<typename T>
-void sort_and_crop_ref(unsigned int nIn, unsigned int nOut, T in[], T out[]) 
+template<typename T>
+void bitonic_sort_and_crop_ref(unsigned int nIn, unsigned int nOut, T in[], T out[]) 
 {  // just an interface
     bitonicSort(in,0, nIn,out, nOut,0); 
 }

--- a/sort/bitonic_sort_new.h
+++ b/sort/bitonic_sort_new.h
@@ -1,0 +1,143 @@
+// define colors
+#ifndef BITONIC_NEW_H
+#define BITONIC_NEW_H
+
+    template <typename T>
+inline T max(T a, T b)  
+{  
+    return (a < b)? b : a;  
+}  
+
+    template <typename T>
+inline T min(T a, T b)  
+{  
+    return (a < b)? a : b;  
+}  
+
+int get_pow2_size(unsigned int n){
+    if (n && !(n&(n-1)))return n;
+    int count=0;
+    while(n) {n>>=1;++count;}
+    return 1<<count;
+}
+
+unsigned int PowerOf2LessThan(unsigned int n){
+    unsigned int i=1;
+    unsigned int prev=1;
+    while (i<n){
+        i<<=1;
+        if (i<n) {
+            prev =i;
+        } else {
+            return prev;
+        }
+    }
+}
+
+template<typename T>
+void bitonicMerge(T in[], int InSize,T out[],int OutSize, bool dir)
+{
+    //printDebug;
+
+    // size == 1 -> pass through
+    if (InSize<=1) { 
+        for(int i=0;i<min(InSize,OutSize);++i) out[i]=in[i]; 
+        return;
+    }
+
+    if (InSize>1){
+        int LowerSize  = PowerOf2LessThan( InSize ); //-- LowerSize >= Size / 2
+        int UpperSize   =  InSize - LowerSize; //-- UpperSize < LowerSiz   
+
+        if (LowerSize < UpperSize) std::cout<<"[ERROR]"<<__FUNCTION__<<" LowerSize ("<<LowerSize<<") not > of UpperSize ("<<UpperSize<<")"<<std::endl;
+
+        for (int i =0 ; i< UpperSize;++i) {
+            if(in[i] > in[i+LowerSize] == dir) 
+            {
+                // this checks should refer to the comments, "just needs to be long enough"
+                if(i<OutSize) out[i] = in[i+LowerSize];
+                if(i+LowerSize<OutSize) out[i+LowerSize] = in[i];
+            }
+            else
+            {
+                if(i<OutSize) out[i] = in[i];
+                if(i+LowerSize<OutSize) out[i+LowerSize] = in[i+LowerSize];
+            }
+        }   
+
+        // Copy the residual at the end. This limits the sorting in the overall descending direction (if out != in).
+        if (LowerSize > UpperSize){
+            for(int i= UpperSize;i<LowerSize; ++i)
+            {
+                if (i<OutSize) out[i] = in[i];
+            }
+        }
+
+        T out2[LowerSize];
+        bitonicMerge(out,LowerSize,out2,LowerSize,dir );
+
+        T out3[UpperSize];
+        bitonicMerge(out+LowerSize, UpperSize, out3,UpperSize,dir); 
+
+        // copy back to out; direction dependent.
+        if (dir) // ascending -- Copy up to OutSize
+        {
+            for(int i=0;i<OutSize;++i) {
+                if(i<UpperSize) out[OutSize-i-1] = out3[UpperSize-i-1];
+                else out[OutSize-i-1] = out2[LowerSize-i-1+UpperSize];
+            }
+
+        }
+        else{ //descending
+            for(int i=0;i<LowerSize;++i) {if(i<OutSize) out[i] =out2[i];}
+            for(int i=LowerSize;i<OutSize;++i) out[i] = out3[i-LowerSize];
+        }
+
+    }// InSize>1
+
+} // bitonicMerge
+
+template<typename T>
+void bitonicSort(T in[],int Start, int InSize,T out[], int OutSize, bool dir )
+{
+    if (InSize <= 1) // copy in-> out and exit
+    {
+        for(int i=0;i<min(InSize,OutSize);++i) out[i] = in[i+Start]; 
+        return ;
+    }
+
+    int  LowerInSize = InSize / 2;
+    int  UpperInSize = InSize - LowerInSize; //-- UpperSize >= LowerSize
+
+    int  LowerOutSize = min( OutSize , LowerInSize );
+    int  UpperOutSize = min( OutSize , UpperInSize );
+
+    // sorted output
+    T OutTmp[LowerOutSize+UpperOutSize];
+
+    // sort first half
+    bitonicSort(in,Start,LowerInSize,OutTmp,LowerOutSize,not dir ); // the not dir enforce the sorting in overall descending direction.
+
+    // sort second half
+    bitonicSort(in,Start+LowerInSize,UpperInSize,OutTmp+LowerOutSize,UpperOutSize,dir);
+
+    // create a temporary output vector "large enough" and then copy back
+    int OutSize2= LowerOutSize+UpperOutSize;
+    T outTmp2[OutSize2]; 
+    bitonicMerge(OutTmp,LowerOutSize+UpperOutSize,outTmp2,OutSize2, dir);
+    //copy back to out the first OutSize
+    for(int i=0;i<OutSize;++i){
+        if (dir) { //ascending
+            out[OutSize-1-i] = outTmp2[OutSize2-1-i];
+        }else{ //descending
+            out[i] =outTmp2[i];
+        }
+    }
+}
+
+    template<typename T>
+void sort_and_crop_ref(unsigned int nIn, unsigned int nOut, T in[], T out[]) 
+{  // just an interface
+    bitonicSort(in,0, nIn,out, nOut,0); 
+}
+#endif


### PR DESCRIPTION
Bitonic sort for Puppi candidates from https://github.com/gpetruc/GlobalCorrelator_HLS/pull/6
Minor changes:
 * moved the definition of the comparison operators to the PuppiObj
 * removed some no longer used functions, and replaced custom `min` function with `std::min`
 * added `bitonic_` in front of the name of the function, to make it clearer especially in case one ends up with multiple sort functions in the scope.